### PR TITLE
feat:学習項目のページネーション実装 close #8

### DIFF
--- a/src/main/java/com/example/learning_exam_manager/repository/StudyItemRepository.java
+++ b/src/main/java/com/example/learning_exam_manager/repository/StudyItemRepository.java
@@ -4,6 +4,8 @@ import com.example.learning_exam_manager.entity.StudyItem;
 import com.example.learning_exam_manager.entity.StudyItem.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -17,5 +19,12 @@ public interface StudyItemRepository extends JpaRepository<StudyItem, Long> {
     List<StudyItem> findByTitleContaining(String title);
     
     List<StudyItem> findBySubjectIdAndTitleContaining(Long subjectId, String title);
-}
 
+    Page<StudyItem> findBySubjectId(Long subjectId, Pageable pageable);
+
+    Page<StudyItem> findBySubjectIdAndStatus(Long subjectId, Status status, Pageable pageable);
+
+    Page<StudyItem> findByTitleContaining(String title, Pageable pageable);
+
+    Page<StudyItem> findBySubjectIdAndTitleContaining(Long subjectId, String title, Pageable pageable);
+}

--- a/src/main/resources/templates/study-items/list.html
+++ b/src/main/resources/templates/study-items/list.html
@@ -19,6 +19,7 @@
         <div class="row mb-3">
             <div class="col-md-8">
                 <form th:action="@{/study-items}" method="get" class="row g-2">
+                    <input type="hidden" name="page" value="0">
                     <div class="col-md-4">
                         <select name="subjectId" class="form-select">
                             <option value="">すべての科目</option>
@@ -91,6 +92,44 @@
                 </tr>
             </tbody>
         </table>
+    <!-- ページネーション -->
+    <nav th:if="${totalPages > 1}" aria-label="ページネーション">
+        <ul class="pagination justify-content-center">
+            <!-- 前のページ -->
+            <li class="page-item" th:classappend="${currentPage == 0 ? 'disabled' : ''}">
+                <a class="page-link" 
+                th:href="@{/study-items(keyword=${keyword}, subjectId=${selectedSubjectId}, page=${currentPage - 1}, size=${pageSize})}"
+                th:if="${currentPage > 0}">前へ</a>
+                <span class="page-link" th:if="${currentPage == 0}">前へ</span>
+            </li>
+            
+            <!-- ページ番号 -->
+            <li th:each="pageNum : ${#numbers.sequence(0, totalPages - 1)}" 
+                class="page-item"
+                th:classappend="${pageNum == currentPage ? 'active' : ''}">
+                <a class="page-link" 
+                th:href="@{/study-items(keyword=${keyword}, subjectId=${selectedSubjectId}, page=${pageNum}, size=${pageSize})}"
+                th:text="${pageNum + 1}"></a>
+            </li>
+            
+            <!-- 次のページ -->
+            <li class="page-item" th:classappend="${currentPage >= totalPages - 1 ? 'disabled' : ''}">
+                <a class="page-link" 
+                th:href="@{/study-items(keyword=${keyword}, subjectId=${selectedSubjectId}, page=${currentPage + 1}, size=${pageSize})}"
+                th:if="${currentPage < totalPages - 1}">次へ</a>
+                <span class="page-link" th:if="${currentPage >= totalPages - 1}">次へ</span>
+            </li>
+        </ul>
+    </nav>
+
+    <!-- ページ情報の表示 -->
+    <div class="text-center mt-3">
+        <p class="text-muted">
+            全 <span th:text="${totalItems}"></span> 件中 
+            <span th:text="${currentPage * pageSize + 1}"></span> - 
+            <span th:text="${currentPage * pageSize + studyItems.size()}"></span> 件を表示
+        </p>
+    </div>
     </div>
     
     <!-- Bootstrap JSを読み込み -->


### PR DESCRIPTION
## 概要
学習項目のページにページネーション機能を実装しました。

## 対応Issue
close #8 

## 変更点
- Repositoryメソッド追加
- Service findAll(Pageable pageable)追加, search(String keyword, Long subjectId, Pageable pageable)追加
- Controller listメソッド更新
- ビュー更新

## 動作確認
[X] データが10件ずつ表示される（デフォルト）
[X] ページネーションコンポーネントが表示される
[X] 「前へ」「次へ」ボタンが動作する
[X] ページ番号をクリックしてページ移動できる
[X] 現在のページがハイライトされる
[X] ページ情報（件数）が正しく表示される
[X] 検索機能とページネーションが同時に動作する
[X] 検索実行時、1ページ目に戻る