### PR TITLE
Feature/exam result/pageable

### DIFF
--- a/src/main/java/com/example/learning_exam_manager/repository/ExamResultRepository.java
+++ b/src/main/java/com/example/learning_exam_manager/repository/ExamResultRepository.java
@@ -5,6 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -12,8 +14,8 @@ import java.util.List;
 @Repository
 public interface ExamResultRepository extends JpaRepository<ExamResult, Long> {
     
+    // 既存のList版メソッド（残しておく）
     List<ExamResult> findByExamId(Long examId);
-    
     List<ExamResult> findByPassed(Boolean passed);
     
     @Query("SELECT er FROM ExamResult er ORDER BY er.takenAt DESC")
@@ -23,7 +25,13 @@ public interface ExamResultRepository extends JpaRepository<ExamResult, Long> {
     List<ExamResult> findByTakenAtBetween(@Param("startDate") LocalDate startDate, 
                                           @Param("endDate") LocalDate endDate);
     
-    // 試験名で部分一致検索（Examとの関連を通じて検索）
+    // 既存のList版（残しておく）
     @Query("SELECT er FROM ExamResult er WHERE er.exam.examName LIKE CONCAT('%', :examName, '%')")
     List<ExamResult> findByExamExamNameContaining(@Param("examName") String examName);
+    
+    // Pageable対応版を追加
+    Page<ExamResult> findByExamId(Long examId, Pageable pageable);
+    
+    @Query("SELECT er FROM ExamResult er WHERE er.exam.examName LIKE CONCAT('%', :examName, '%')")
+    Page<ExamResult> findByExamExamNameContaining(@Param("examName") String examName, Pageable pageable);
 }

--- a/src/main/java/com/example/learning_exam_manager/service/ExamResultService.java
+++ b/src/main/java/com/example/learning_exam_manager/service/ExamResultService.java
@@ -9,7 +9,8 @@ import com.example.learning_exam_manager.repository.ExamResultRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -31,6 +32,11 @@ public class ExamResultService {
         return examResultRepository.findAll().stream()
                 .map(this::toDto)
                 .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ExamResultDto> findAll(Pageable pageable) {
+        return examResultRepository.findAll(pageable).map(this::toDto);
     }
     
     @Transactional(readOnly = true)
@@ -56,6 +62,12 @@ public class ExamResultService {
         return examResultRepository.findByExamExamNameContaining(keyword.trim()).stream()
                 .map(this::toDto)
                 .collect(Collectors.toList());
+    }
+
+
+    @Transactional(readOnly = true)
+    public Page<ExamResultDto> search(String keyword, Pageable pageable) {
+        return examResultRepository.findByExamExamNameContaining(keyword.trim(), pageable).map(this::toDto);
     }
     
     @Transactional(readOnly = true)

--- a/src/main/resources/templates/exam-results/list.html
+++ b/src/main/resources/templates/exam-results/list.html
@@ -21,6 +21,7 @@
         <div class="row mb-3">
             <div class="col-md-6">
                 <form th:action="@{/exam-results}" method="get" class="d-flex">
+                    <input type="hidden" name="page" value="0">
                     <input type="text" 
                            name="keyword" 
                            class="form-control me-2" 
@@ -78,6 +79,45 @@
                 </tr>
             </tbody>
         </table>
+
+        <!-- ページネーション -->
+        <nav th:if="${totalPages > 1}" aria-label="ページネーション">
+            <ul class="pagination justify-content-center">
+                <!-- 前のページ -->
+                <li class="page-item" th:classappend="${currentPage == 0 ? 'disabled' : ''}">
+                    <a class="page-link" 
+                       th:href="@{/exam-results(keyword=${keyword}, page=${currentPage - 1}, size=${pageSize})}"
+                       th:if="${currentPage > 0}">前へ</a>
+                    <span class="page-link" th:if="${currentPage == 0}">前へ</span>
+                </li>
+                
+                <!-- ページ番号 -->
+                <li th:each="pageNum : ${#numbers.sequence(0, totalPages - 1)}" 
+                    class="page-item"
+                    th:classappend="${pageNum == currentPage ? 'active' : ''}">
+                    <a class="page-link" 
+                       th:href="@{/exam-results(keyword=${keyword}, page=${pageNum}, size=${pageSize})}"
+                       th:text="${pageNum + 1}"></a>
+                </li>
+                
+                <!-- 次のページ -->
+                <li class="page-item" th:classappend="${currentPage >= totalPages - 1 ? 'disabled' : ''}">
+                    <a class="page-link" 
+                       th:href="@{/exam-results(keyword=${keyword}, page=${currentPage + 1}, size=${pageSize})}"
+                       th:if="${currentPage < totalPages - 1}">次へ</a>
+                    <span class="page-link" th:if="${currentPage >= totalPages - 1}">次へ</span>
+                </li>
+            </ul>
+        </nav>
+        
+        <!-- ページ情報の表示 -->
+        <div class="text-center mt-3">
+            <p class="text-muted">
+                全 <span th:text="${totalItems}"></span> 件中 
+                <span th:text="${currentPage * pageSize + 1}"></span> - 
+                <span th:text="${currentPage * pageSize + examResults.size()}"></span> 件を表示
+            </p>
+        </div>
     </div>
     
     <!-- Bootstrap JSを読み込み -->


### PR DESCRIPTION
## 概要
試験結果ページにページネーション機能を実装しました。

## 対応Issue
close #10 

## 変更点
ExamResultにおいて
- Repositoryにメソッド追加
- Service更新
- Controller更新
- ビュー更新

## 動作確認
[X] データが10件ずつ表示される（デフォルト）
[X] データが受験日の降順（新しい順）でソートされている
[X] ページネーションコンポーネントが表示される
[X] 「前へ」「次へ」ボタンが動作する
[X] ページ番号をクリックしてページ移動できる
[X] 現在のページがハイライトされる
[X] ページ情報（件数）が正しく表示される
[X] 検索機能とページネーションが同時に動作する
[X] 検索実行時、1ページ目に戻る
[X] 検索条件がページネーションリンクで保持される
