### PR TITLE
feat:エラーハンドリングを実装 close #12

### DIFF
--- a/src/main/java/com/example/learning_exam_manager/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/learning_exam_manager/exception/GlobalExceptionHandler.java
@@ -1,0 +1,45 @@
+package com.example.learning_exam_manager.exception;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+    
+    private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+    
+    // 一般的な例外の処理
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public String handleException(Exception e, Model model) {
+        logger.error("予期しないエラーが発生しました", e);
+        model.addAttribute("error", "システムエラーが発生しました。しばらく時間をおいて再度お試しください。");
+        model.addAttribute("title", "エラー");
+        return "error/error";
+    }
+    
+    // リソースが見つからない場合の処理
+    @ExceptionHandler(ResourceNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public String handleResourceNotFoundException(ResourceNotFoundException e, Model model) {
+        logger.warn("リソースが見つかりません: {}", e.getMessage());
+        model.addAttribute("error", e.getMessage());
+        model.addAttribute("title", "404 - ページが見つかりません");
+        return "error/404";
+    }
+    
+    // バリデーションエラーの処理
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public String handleIllegalArgumentException(IllegalArgumentException e, Model model) {
+        logger.warn("不正なリクエスト: {}", e.getMessage());
+        model.addAttribute("error", e.getMessage());
+        model.addAttribute("title", "400 - 不正なリクエスト");
+        return "error/400";
+    }
+}

--- a/src/main/java/com/example/learning_exam_manager/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/example/learning_exam_manager/exception/ResourceNotFoundException.java
@@ -1,0 +1,12 @@
+package com.example.learning_exam_manager.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+    
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+    
+    public ResourceNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/example/learning_exam_manager/service/SubjectService.java
+++ b/src/main/java/com/example/learning_exam_manager/service/SubjectService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import com.example.learning_exam_manager.exception.ResourceNotFoundException;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -60,7 +61,7 @@ public class SubjectService {
     @Transactional(readOnly = true)
     public SubjectDto findById(Long id) {
         Subject subject = subjectRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("科目が見つかりません: " + id));
+                .orElseThrow(() -> new ResourceNotFoundException("科目が見つかりません: " + id));
         return toDto(subject);
     }
     
@@ -72,7 +73,7 @@ public class SubjectService {
     
     public SubjectDto update(Long id, SubjectForm form) {
         Subject subject = subjectRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("科目が見つかりません: " + id));
+                .orElseThrow(() -> new ResourceNotFoundException("科目が見つかりません: " + id));
         subject.setName(form.getName());
         subject.setDescription(form.getDescription());
         Subject updated = subjectRepository.save(subject);

--- a/src/main/resources/templates/error/400.html
+++ b/src/main/resources/templates/error/400.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title th:text="${title != null ? title : '400 - 不正なリクエスト'}">400 - 不正なリクエスト</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <th:block th:replace="~{fragments/layout :: footer-styles}"></th:block>
+</head>
+<body>
+    <div th:replace="~{fragments/layout :: navbar}"></div>
+    
+    <div class="container mt-5">
+        <div class="row justify-content-center">
+            <div class="col-md-8">
+                <div class="card">
+                    <div class="card-body text-center">
+                        <h1 class="display-1 text-danger">404</h1>
+                        <p class="lead" th:text="${error != null ? error : 'ページが見つかりません'}"></p>
+                        <a href="/" class="btn btn-primary mt-3">ホームに戻る</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    
+    <div th:replace="~{fragments/layout :: bootstrap-js}"></div>
+</body>
+</html>

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title th:text="${title != null ? title : '404 - ページが見つかりません'}">404 - ページが見つかりません</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <th:block th:replace="~{fragments/layout :: footer-styles}"></th:block>
+</head>
+<body>
+    <div th:replace="~{fragments/layout :: navbar}"></div>
+    
+    <div class="container mt-5">
+        <div class="row justify-content-center">
+            <div class="col-md-8">
+                <div class="card">
+                    <div class="card-body text-center">
+                        <h1 class="display-1 text-danger">404</h1>
+                        <p class="lead" th:text="${error != null ? error : 'ページが見つかりません'}"></p>
+                        <a href="/" class="btn btn-primary mt-3">ホームに戻る</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    
+    <div th:replace="~{fragments/layout :: bootstrap-js}"></div>
+</body>
+</html>

--- a/src/main/resources/templates/error/error.html
+++ b/src/main/resources/templates/error/error.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title th:text="${title != null ? title : 'エラー'}">エラー</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+<th:block th:replace="~{fragments/layout :: footer-styles}"></th:block>
+</head>
+<body>
+    <div th:replace="~{fragments/layout :: navbar}"></div>
+    
+    <div class="container mt-5">
+        <div class="row justify-content-center">
+            <div class="col-md-8">
+                <div class="card">
+                    <div class="card-body text-center">
+                        <h1 class="display-1 text-danger">エラー</h1>
+                        <p class="lead" th:text="${error != null ? error : 'システムエラーが発生しました'}"></p>
+                        <a href="/" class="btn btn-primary mt-3">ホームに戻る</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    
+    <div th:replace="~{fragments/layout :: bootstrap-js}"></div>
+</body>
+</html>


### PR DESCRIPTION
## 概要
エラーハンドリングを実装しました

## 対応Issue
close #12 

## 変更点
- create GlobalExceptionHandler.java
- create ResourceNotFoundException.java
- create 400.html
- create 404.html
- create error.html

## 動作確認
- [X] エラーページが表示される
- [X] 適切なエラーメッセージが表示される
- [X] ホームに戻るボタンが動作する

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds centralized exception handling and user-friendly error pages.
> 
> - Introduces `GlobalExceptionHandler` to map exceptions to `error/error`, `error/404`, and `error/400` with appropriate HTTP statuses
> - Adds custom `ResourceNotFoundException`
> - Updates `SubjectService` to throw `ResourceNotFoundException` in `findById` and `update`
> - Adds Thymeleaf templates: `templates/error/400.html`, `templates/error/404.html`, and `templates/error/error.html`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e01b86a219b56d90b8648964df5dfde729675f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->