### PR TITLE
Fix/404page/etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ out/
 
 ### 機密情報 ###
 application.properties
+logs/

--- a/logs/application.2026-01-12.log
+++ b/logs/application.2026-01-12.log
@@ -1,0 +1,497 @@
+2026-01-12 22:15:10 [background-preinit] INFO  o.h.validator.internal.util.Version - HV000001: Hibernate Validator 9.0.1.Final
+2026-01-12 22:15:10 [Test worker] INFO  c.e.l.LearningExamManagerApplicationTests - Starting LearningExamManagerApplicationTests using Java 23.0.2 with PID 30036 (started by fumikun.wen in /Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager)
+2026-01-12 22:15:10 [Test worker] DEBUG c.e.l.LearningExamManagerApplicationTests - Running with Spring Boot v4.0.1, Spring v7.0.2
+2026-01-12 22:15:10 [Test worker] INFO  c.e.l.LearningExamManagerApplicationTests - No active profile set, falling back to 1 default profile: "default"
+2026-01-12 22:15:10 [Test worker] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Bootstrapping Spring Data JPA repositories in DEFAULT mode.
+2026-01-12 22:15:10 [Test worker] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Finished Spring Data repository scanning in 22 ms. Found 4 JPA repository interfaces.
+2026-01-12 22:15:11 [Test worker] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Starting...
+2026-01-12 22:15:11 [Test worker] INFO  com.zaxxer.hikari.pool.HikariPool - HikariPool-1 - Added connection com.mysql.cj.jdbc.ConnectionImpl@53e4a19e
+2026-01-12 22:15:11 [Test worker] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Start completed.
+2026-01-12 22:15:11 [Test worker] INFO  org.flywaydb.core.FlywayExecutor - Database: jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8 (MySQL 9.3)
+2026-01-12 22:15:11 [Test worker] WARN  o.f.c.i.database.base.Database - Using MySQL 9.3 which is newer than the version Flyway has been verified with. The latest verified version of MySQL is 8.1.
+2026-01-12 22:15:11 [Test worker] INFO  o.f.core.internal.command.DbValidate - Successfully validated 2 migrations (execution time 00:00.032s)
+2026-01-12 22:15:11 [Test worker] INFO  o.f.core.internal.command.DbMigrate - Current version of schema `learning_exam_manager`: 2
+2026-01-12 22:15:11 [Test worker] INFO  o.f.core.internal.command.DbMigrate - Schema `learning_exam_manager` is up to date. No migration necessary.
+2026-01-12 22:15:11 [Test worker] INFO  org.hibernate.orm.jpa - HHH008540: Processing PersistenceUnitInfo [name: default]
+2026-01-12 22:15:11 [Test worker] INFO  org.hibernate.orm.core - HHH000001: Hibernate ORM core version 7.2.0.Final
+2026-01-12 22:15:11 [Test worker] INFO  o.s.o.j.p.SpringPersistenceUnitInfo - No LoadTimeWeaver setup: ignoring JPA class transformer
+2026-01-12 22:15:11 [Test worker] WARN  org.hibernate.orm.deprecation - HHH90000025: MySQLDialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
+2026-01-12 22:15:11 [Test worker] INFO  o.hibernate.orm.connections.pooling - HHH10001005: Database info:
+	Database JDBC URL [jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8]
+	Database driver: MySQL Connector/J
+	Database dialect: MySQLDialect
+	Database version: 9.3
+	Default catalog/schema: learning_exam_manager/undefined
+	Autocommit mode: undefined/unknown
+	Isolation level: REPEATABLE_READ [default REPEATABLE_READ]
+	JDBC fetch size: none
+	Pool: DataSourceConnectionProvider
+	Minimum pool size: undefined/unknown
+	Maximum pool size: undefined/unknown
+2026-01-12 22:15:12 [Test worker] INFO  org.hibernate.orm.core - HHH000489: No JTA platform available (set 'hibernate.transaction.jta.platform' to enable JTA platform integration)
+2026-01-12 22:15:12 [Test worker] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Initialized JPA EntityManagerFactory for persistence unit 'default'
+2026-01-12 22:15:12 [Test worker] INFO  o.s.d.j.r.q.QueryEnhancerFactories - Hibernate is in classpath; If applicable, HQL parser will be used.
+2026-01-12 22:15:12 [Test worker] WARN  o.s.b.j.a.JpaBaseConfiguration$JpaWebConfiguration - spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering. Explicitly configure spring.jpa.open-in-view to disable this warning
+2026-01-12 22:15:13 [Test worker] INFO  c.e.l.LearningExamManagerApplicationTests - Started LearningExamManagerApplicationTests in 2.493 seconds (process running for 3.085)
+2026-01-12 22:15:13 [SpringApplicationShutdownHook] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Closing JPA EntityManagerFactory for persistence unit 'default'
+2026-01-12 22:15:13 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown initiated...
+2026-01-12 22:15:13 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown completed.
+2026-01-12 22:19:46 [background-preinit] INFO  o.h.validator.internal.util.Version - HV000001: Hibernate Validator 9.0.1.Final
+2026-01-12 22:19:46 [Test worker] INFO  c.e.l.LearningExamManagerApplicationTests - Starting LearningExamManagerApplicationTests using Java 23.0.2 with PID 32567 (started by fumikun.wen in /Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager)
+2026-01-12 22:19:46 [Test worker] DEBUG c.e.l.LearningExamManagerApplicationTests - Running with Spring Boot v4.0.1, Spring v7.0.2
+2026-01-12 22:19:46 [Test worker] INFO  c.e.l.LearningExamManagerApplicationTests - No active profile set, falling back to 1 default profile: "default"
+2026-01-12 22:19:46 [Test worker] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Bootstrapping Spring Data JPA repositories in DEFAULT mode.
+2026-01-12 22:19:46 [Test worker] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Finished Spring Data repository scanning in 21 ms. Found 4 JPA repository interfaces.
+2026-01-12 22:19:46 [Test worker] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Starting...
+2026-01-12 22:19:46 [Test worker] INFO  com.zaxxer.hikari.pool.HikariPool - HikariPool-1 - Added connection com.mysql.cj.jdbc.ConnectionImpl@53e4a19e
+2026-01-12 22:19:46 [Test worker] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Start completed.
+2026-01-12 22:19:46 [Test worker] INFO  org.flywaydb.core.FlywayExecutor - Database: jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8 (MySQL 9.3)
+2026-01-12 22:19:46 [Test worker] WARN  o.f.c.i.database.base.Database - Using MySQL 9.3 which is newer than the version Flyway has been verified with. The latest verified version of MySQL is 8.1.
+2026-01-12 22:19:46 [Test worker] INFO  o.f.core.internal.command.DbValidate - Successfully validated 2 migrations (execution time 00:00.020s)
+2026-01-12 22:19:46 [Test worker] INFO  o.f.core.internal.command.DbMigrate - Current version of schema `learning_exam_manager`: 2
+2026-01-12 22:19:46 [Test worker] INFO  o.f.core.internal.command.DbMigrate - Schema `learning_exam_manager` is up to date. No migration necessary.
+2026-01-12 22:19:46 [Test worker] INFO  org.hibernate.orm.jpa - HHH008540: Processing PersistenceUnitInfo [name: default]
+2026-01-12 22:19:46 [Test worker] INFO  org.hibernate.orm.core - HHH000001: Hibernate ORM core version 7.2.0.Final
+2026-01-12 22:19:46 [Test worker] INFO  o.s.o.j.p.SpringPersistenceUnitInfo - No LoadTimeWeaver setup: ignoring JPA class transformer
+2026-01-12 22:19:47 [Test worker] WARN  org.hibernate.orm.deprecation - HHH90000025: MySQLDialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
+2026-01-12 22:19:47 [Test worker] INFO  o.hibernate.orm.connections.pooling - HHH10001005: Database info:
+	Database JDBC URL [jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8]
+	Database driver: MySQL Connector/J
+	Database dialect: MySQLDialect
+	Database version: 9.3
+	Default catalog/schema: learning_exam_manager/undefined
+	Autocommit mode: undefined/unknown
+	Isolation level: REPEATABLE_READ [default REPEATABLE_READ]
+	JDBC fetch size: none
+	Pool: DataSourceConnectionProvider
+	Minimum pool size: undefined/unknown
+	Maximum pool size: undefined/unknown
+2026-01-12 22:19:47 [Test worker] INFO  org.hibernate.orm.core - HHH000489: No JTA platform available (set 'hibernate.transaction.jta.platform' to enable JTA platform integration)
+2026-01-12 22:19:47 [Test worker] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Initialized JPA EntityManagerFactory for persistence unit 'default'
+2026-01-12 22:19:47 [Test worker] INFO  o.s.d.j.r.q.QueryEnhancerFactories - Hibernate is in classpath; If applicable, HQL parser will be used.
+2026-01-12 22:19:48 [Test worker] WARN  o.s.b.j.a.JpaBaseConfiguration$JpaWebConfiguration - spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering. Explicitly configure spring.jpa.open-in-view to disable this warning
+2026-01-12 22:19:48 [Test worker] INFO  c.e.l.LearningExamManagerApplicationTests - Started LearningExamManagerApplicationTests in 2.411 seconds (process running for 2.953)
+2026-01-12 22:19:48 [SpringApplicationShutdownHook] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Closing JPA EntityManagerFactory for persistence unit 'default'
+2026-01-12 22:19:48 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown initiated...
+2026-01-12 22:19:48 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown completed.
+2026-01-12 22:20:32 [background-preinit] INFO  o.h.validator.internal.util.Version - HV000001: Hibernate Validator 9.0.1.Final
+2026-01-12 22:20:32 [main] INFO  c.e.l.LearningExamManagerApplication - Starting LearningExamManagerApplication using Java 23.0.2 with PID 33326 (/Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager/build/classes/java/main started by fumikun.wen in /Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager)
+2026-01-12 22:20:32 [main] DEBUG c.e.l.LearningExamManagerApplication - Running with Spring Boot v4.0.1, Spring v7.0.2
+2026-01-12 22:20:32 [main] INFO  c.e.l.LearningExamManagerApplication - No active profile set, falling back to 1 default profile: "default"
+2026-01-12 22:20:33 [main] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Bootstrapping Spring Data JPA repositories in DEFAULT mode.
+2026-01-12 22:20:33 [main] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Finished Spring Data repository scanning in 20 ms. Found 4 JPA repository interfaces.
+2026-01-12 22:20:33 [main] INFO  o.s.boot.tomcat.TomcatWebServer - Tomcat initialized with port 8080 (http)
+2026-01-12 22:20:33 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8080"]
+2026-01-12 22:20:33 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
+2026-01-12 22:20:33 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/11.0.15]
+2026-01-12 22:20:33 [main] INFO  o.s.b.w.c.s.WebApplicationContextInitializer - Root WebApplicationContext: initialization completed in 523 ms
+2026-01-12 22:20:33 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Starting...
+2026-01-12 22:20:33 [main] INFO  com.zaxxer.hikari.pool.HikariPool - HikariPool-1 - Added connection com.mysql.cj.jdbc.ConnectionImpl@58164e9a
+2026-01-12 22:20:33 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Start completed.
+2026-01-12 22:20:33 [main] INFO  org.flywaydb.core.FlywayExecutor - Database: jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8 (MySQL 9.3)
+2026-01-12 22:20:33 [main] WARN  o.f.c.i.database.base.Database - Using MySQL 9.3 which is newer than the version Flyway has been verified with. The latest verified version of MySQL is 8.1.
+2026-01-12 22:20:33 [main] INFO  o.f.core.internal.command.DbValidate - Successfully validated 2 migrations (execution time 00:00.021s)
+2026-01-12 22:20:33 [main] INFO  o.f.core.internal.command.DbMigrate - Current version of schema `learning_exam_manager`: 2
+2026-01-12 22:20:33 [main] INFO  o.f.core.internal.command.DbMigrate - Schema `learning_exam_manager` is up to date. No migration necessary.
+2026-01-12 22:20:33 [main] INFO  org.hibernate.orm.jpa - HHH008540: Processing PersistenceUnitInfo [name: default]
+2026-01-12 22:20:33 [main] INFO  org.hibernate.orm.core - HHH000001: Hibernate ORM core version 7.2.0.Final
+2026-01-12 22:20:34 [main] INFO  o.s.o.j.p.SpringPersistenceUnitInfo - No LoadTimeWeaver setup: ignoring JPA class transformer
+2026-01-12 22:20:34 [main] WARN  org.hibernate.orm.deprecation - HHH90000025: MySQLDialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
+2026-01-12 22:20:34 [main] INFO  o.hibernate.orm.connections.pooling - HHH10001005: Database info:
+	Database JDBC URL [jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8]
+	Database driver: MySQL Connector/J
+	Database dialect: MySQLDialect
+	Database version: 9.3
+	Default catalog/schema: learning_exam_manager/undefined
+	Autocommit mode: undefined/unknown
+	Isolation level: REPEATABLE_READ [default REPEATABLE_READ]
+	JDBC fetch size: none
+	Pool: DataSourceConnectionProvider
+	Minimum pool size: undefined/unknown
+	Maximum pool size: undefined/unknown
+2026-01-12 22:20:34 [main] INFO  org.hibernate.orm.core - HHH000489: No JTA platform available (set 'hibernate.transaction.jta.platform' to enable JTA platform integration)
+2026-01-12 22:20:34 [main] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Initialized JPA EntityManagerFactory for persistence unit 'default'
+2026-01-12 22:20:34 [main] INFO  o.s.d.j.r.q.QueryEnhancerFactories - Hibernate is in classpath; If applicable, HQL parser will be used.
+2026-01-12 22:20:35 [main] WARN  o.s.b.j.a.JpaBaseConfiguration$JpaWebConfiguration - spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering. Explicitly configure spring.jpa.open-in-view to disable this warning
+2026-01-12 22:20:35 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8080"]
+2026-01-12 22:20:35 [main] INFO  o.s.boot.tomcat.TomcatWebServer - Tomcat started on port 8080 (http) with context path '/'
+2026-01-12 22:20:35 [main] INFO  c.e.l.LearningExamManagerApplication - Started LearningExamManagerApplication in 2.645 seconds (process running for 2.844)
+2026-01-12 22:20:45 [http-nio-8080-exec-1] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
+2026-01-12 22:20:45 [http-nio-8080-exec-1] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
+2026-01-12 22:20:45 [http-nio-8080-exec-1] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 2 ms
+2026-01-12 22:21:26 [http-nio-8080-exec-3] DEBUG c.e.l.service.SubjectService - すべての科目を取得します
+2026-01-12 22:21:26 [http-nio-8080-exec-3] INFO  c.e.l.service.SubjectService - 科目を10件取得しました
+2026-01-12 22:21:43 [http-nio-8080-exec-5] DEBUG c.e.l.controller.SubjectController - 科目一覧を表示します: keyword=null, page=0, size=10
+2026-01-12 22:21:43 [http-nio-8080-exec-5] DEBUG c.e.l.service.SubjectService - 科目一覧をページングして取得します
+2026-01-12 22:21:43 [http-nio-8080-exec-5] INFO  c.e.l.service.SubjectService - 科目を10件取得しました
+2026-01-12 22:21:43 [http-nio-8080-exec-5] INFO  c.e.l.controller.SubjectController - 科目一覧を表示しました: totalPages=1, totalItems=10, pageSize=10
+2026-01-12 22:22:01 [http-nio-8080-exec-7] DEBUG c.e.l.controller.SubjectController - 科目登録画面を表示します
+2026-01-12 22:22:01 [http-nio-8080-exec-7] INFO  c.e.l.controller.SubjectController - 科目登録画面を表示しました
+2026-01-12 22:22:04 [http-nio-8080-exec-9] INFO  c.e.l.service.SubjectService - 新しい科目を作成します: test
+2026-01-12 22:22:04 [http-nio-8080-exec-9] INFO  c.e.l.service.SubjectService - 科目を作成しました: ID=13, 名前=test
+2026-01-12 22:22:04 [http-nio-8080-exec-9] INFO  c.e.l.controller.SubjectController - 科目を登録しました: 名前=test
+2026-01-12 22:22:04 [http-nio-8080-exec-9] INFO  c.e.l.controller.SubjectController - リダイレクト先に遷移します
+2026-01-12 22:22:04 [http-nio-8080-exec-10] DEBUG c.e.l.controller.SubjectController - 科目一覧を表示します: keyword=null, page=0, size=10
+2026-01-12 22:22:04 [http-nio-8080-exec-10] DEBUG c.e.l.service.SubjectService - 科目一覧をページングして取得します
+2026-01-12 22:22:04 [http-nio-8080-exec-10] INFO  c.e.l.service.SubjectService - 科目を11件取得しました
+2026-01-12 22:22:04 [http-nio-8080-exec-10] INFO  c.e.l.controller.SubjectController - 科目一覧を表示しました: totalPages=2, totalItems=11, pageSize=10
+2026-01-12 22:25:18 [http-nio-8080-exec-2] DEBUG c.e.l.controller.SubjectController - 科目一覧を表示します: keyword=, page=1, size=10
+2026-01-12 22:25:18 [http-nio-8080-exec-2] DEBUG c.e.l.service.SubjectService - 科目一覧をページングして取得します
+2026-01-12 22:25:18 [http-nio-8080-exec-2] INFO  c.e.l.service.SubjectService - 科目を11件取得しました
+2026-01-12 22:25:18 [http-nio-8080-exec-2] INFO  c.e.l.controller.SubjectController - 科目一覧を表示しました: totalPages=2, totalItems=11, pageSize=10
+2026-01-12 22:28:27 [SpringApplicationShutdownHook] INFO  o.s.boot.tomcat.GracefulShutdown - Commencing graceful shutdown. Waiting for active requests to complete
+2026-01-12 22:28:27 [tomcat-shutdown] INFO  o.s.boot.tomcat.GracefulShutdown - Graceful shutdown complete
+2026-01-12 22:28:27 [SpringApplicationShutdownHook] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Closing JPA EntityManagerFactory for persistence unit 'default'
+2026-01-12 22:28:27 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown initiated...
+2026-01-12 22:28:27 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown completed.
+2026-01-12 22:28:52 [background-preinit] INFO  o.h.validator.internal.util.Version - HV000001: Hibernate Validator 9.0.1.Final
+2026-01-12 22:28:52 [main] INFO  c.e.l.LearningExamManagerApplication - Starting LearningExamManagerApplication using Java 23.0.2 with PID 37759 (/Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager/build/classes/java/main started by fumikun.wen in /Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager)
+2026-01-12 22:28:52 [main] DEBUG c.e.l.LearningExamManagerApplication - Running with Spring Boot v4.0.1, Spring v7.0.2
+2026-01-12 22:28:52 [main] INFO  c.e.l.LearningExamManagerApplication - No active profile set, falling back to 1 default profile: "default"
+2026-01-12 22:28:53 [main] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Bootstrapping Spring Data JPA repositories in DEFAULT mode.
+2026-01-12 22:28:53 [main] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Finished Spring Data repository scanning in 19 ms. Found 4 JPA repository interfaces.
+2026-01-12 22:28:53 [main] INFO  o.s.boot.tomcat.TomcatWebServer - Tomcat initialized with port 8080 (http)
+2026-01-12 22:28:53 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8080"]
+2026-01-12 22:28:53 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
+2026-01-12 22:28:53 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/11.0.15]
+2026-01-12 22:28:53 [main] INFO  o.s.b.w.c.s.WebApplicationContextInitializer - Root WebApplicationContext: initialization completed in 469 ms
+2026-01-12 22:28:53 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Starting...
+2026-01-12 22:28:53 [main] INFO  com.zaxxer.hikari.pool.HikariPool - HikariPool-1 - Added connection com.mysql.cj.jdbc.ConnectionImpl@4f26425b
+2026-01-12 22:28:53 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Start completed.
+2026-01-12 22:28:53 [main] INFO  org.flywaydb.core.FlywayExecutor - Database: jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8 (MySQL 9.3)
+2026-01-12 22:28:53 [main] WARN  o.f.c.i.database.base.Database - Using MySQL 9.3 which is newer than the version Flyway has been verified with. The latest verified version of MySQL is 8.1.
+2026-01-12 22:28:53 [main] INFO  o.f.core.internal.command.DbValidate - Successfully validated 2 migrations (execution time 00:00.016s)
+2026-01-12 22:28:53 [main] INFO  o.f.core.internal.command.DbMigrate - Current version of schema `learning_exam_manager`: 2
+2026-01-12 22:28:53 [main] INFO  o.f.core.internal.command.DbMigrate - Schema `learning_exam_manager` is up to date. No migration necessary.
+2026-01-12 22:28:53 [main] INFO  org.hibernate.orm.jpa - HHH008540: Processing PersistenceUnitInfo [name: default]
+2026-01-12 22:28:53 [main] INFO  org.hibernate.orm.core - HHH000001: Hibernate ORM core version 7.2.0.Final
+2026-01-12 22:28:54 [main] INFO  o.s.o.j.p.SpringPersistenceUnitInfo - No LoadTimeWeaver setup: ignoring JPA class transformer
+2026-01-12 22:28:54 [main] WARN  org.hibernate.orm.deprecation - HHH90000025: MySQLDialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
+2026-01-12 22:28:54 [main] INFO  o.hibernate.orm.connections.pooling - HHH10001005: Database info:
+	Database JDBC URL [jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8]
+	Database driver: MySQL Connector/J
+	Database dialect: MySQLDialect
+	Database version: 9.3
+	Default catalog/schema: learning_exam_manager/undefined
+	Autocommit mode: undefined/unknown
+	Isolation level: REPEATABLE_READ [default REPEATABLE_READ]
+	JDBC fetch size: none
+	Pool: DataSourceConnectionProvider
+	Minimum pool size: undefined/unknown
+	Maximum pool size: undefined/unknown
+2026-01-12 22:28:54 [main] INFO  org.hibernate.orm.core - HHH000489: No JTA platform available (set 'hibernate.transaction.jta.platform' to enable JTA platform integration)
+2026-01-12 22:28:54 [main] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Initialized JPA EntityManagerFactory for persistence unit 'default'
+2026-01-12 22:28:54 [main] INFO  o.s.d.j.r.q.QueryEnhancerFactories - Hibernate is in classpath; If applicable, HQL parser will be used.
+2026-01-12 22:28:55 [main] WARN  o.s.b.j.a.JpaBaseConfiguration$JpaWebConfiguration - spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering. Explicitly configure spring.jpa.open-in-view to disable this warning
+2026-01-12 22:28:55 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8080"]
+2026-01-12 22:28:55 [main] INFO  o.s.boot.tomcat.TomcatWebServer - Tomcat started on port 8080 (http) with context path '/'
+2026-01-12 22:28:55 [main] INFO  c.e.l.LearningExamManagerApplication - Started LearningExamManagerApplication in 2.487 seconds (process running for 2.66)
+2026-01-12 22:28:58 [http-nio-8080-exec-1] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
+2026-01-12 22:28:58 [http-nio-8080-exec-1] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
+2026-01-12 22:28:58 [http-nio-8080-exec-1] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 2 ms
+2026-01-12 22:28:58 [http-nio-8080-exec-1] DEBUG c.e.l.controller.SubjectController - 科目一覧を表示します: keyword=, page=1, size=10
+2026-01-12 22:28:58 [http-nio-8080-exec-1] DEBUG c.e.l.service.SubjectService - 科目一覧をページングして取得します
+2026-01-12 22:28:58 [http-nio-8080-exec-1] INFO  c.e.l.service.SubjectService - 科目を11件取得しました
+2026-01-12 22:28:58 [http-nio-8080-exec-1] INFO  c.e.l.controller.SubjectController - 科目一覧を表示しました: totalPages=2, totalItems=11, pageSize=10
+2026-01-12 22:29:22 [http-nio-8080-exec-5] DEBUG c.e.l.controller.SubjectController - 科目一覧を表示します: keyword=null, page=0, size=10
+2026-01-12 22:29:22 [http-nio-8080-exec-5] DEBUG c.e.l.service.SubjectService - 科目一覧をページングして取得します
+2026-01-12 22:29:22 [http-nio-8080-exec-5] INFO  c.e.l.service.SubjectService - 科目を11件取得しました
+2026-01-12 22:29:22 [http-nio-8080-exec-5] INFO  c.e.l.controller.SubjectController - 科目一覧を表示しました: totalPages=2, totalItems=11, pageSize=10
+2026-01-12 22:29:35 [http-nio-8080-exec-7] DEBUG c.e.l.controller.SubjectController - 科目一覧を表示します: keyword=, page=1, size=10
+2026-01-12 22:29:35 [http-nio-8080-exec-7] DEBUG c.e.l.service.SubjectService - 科目一覧をページングして取得します
+2026-01-12 22:29:35 [http-nio-8080-exec-7] INFO  c.e.l.service.SubjectService - 科目を11件取得しました
+2026-01-12 22:29:35 [http-nio-8080-exec-7] INFO  c.e.l.controller.SubjectController - 科目一覧を表示しました: totalPages=2, totalItems=11, pageSize=10
+2026-01-12 22:29:37 [http-nio-8080-exec-8] DEBUG c.e.l.controller.SubjectController - 科目一覧を表示します: keyword=, page=0, size=10
+2026-01-12 22:29:37 [http-nio-8080-exec-8] DEBUG c.e.l.service.SubjectService - 科目一覧をページングして取得します
+2026-01-12 22:29:37 [http-nio-8080-exec-8] INFO  c.e.l.service.SubjectService - 科目を11件取得しました
+2026-01-12 22:29:37 [http-nio-8080-exec-8] INFO  c.e.l.controller.SubjectController - 科目一覧を表示しました: totalPages=2, totalItems=11, pageSize=10
+2026-01-12 22:29:38 [http-nio-8080-exec-9] DEBUG c.e.l.controller.SubjectController - 科目一覧を表示します: keyword=, page=0, size=10
+2026-01-12 22:29:38 [http-nio-8080-exec-9] DEBUG c.e.l.service.SubjectService - 科目一覧をページングして取得します
+2026-01-12 22:29:38 [http-nio-8080-exec-9] INFO  c.e.l.service.SubjectService - 科目を11件取得しました
+2026-01-12 22:29:38 [http-nio-8080-exec-9] INFO  c.e.l.controller.SubjectController - 科目一覧を表示しました: totalPages=2, totalItems=11, pageSize=10
+2026-01-12 22:29:40 [http-nio-8080-exec-1] DEBUG c.e.l.controller.SubjectController - 科目一覧を表示します: keyword=, page=0, size=10
+2026-01-12 22:29:40 [http-nio-8080-exec-1] DEBUG c.e.l.service.SubjectService - 科目一覧をページングして取得します
+2026-01-12 22:29:40 [http-nio-8080-exec-1] INFO  c.e.l.service.SubjectService - 科目を11件取得しました
+2026-01-12 22:29:40 [http-nio-8080-exec-1] INFO  c.e.l.controller.SubjectController - 科目一覧を表示しました: totalPages=2, totalItems=11, pageSize=10
+2026-01-12 22:49:51 [SpringApplicationShutdownHook] INFO  o.s.boot.tomcat.GracefulShutdown - Commencing graceful shutdown. Waiting for active requests to complete
+2026-01-12 22:49:51 [tomcat-shutdown] INFO  o.s.boot.tomcat.GracefulShutdown - Graceful shutdown complete
+2026-01-12 22:49:51 [SpringApplicationShutdownHook] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Closing JPA EntityManagerFactory for persistence unit 'default'
+2026-01-12 22:49:52 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown initiated...
+2026-01-12 22:49:52 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown completed.
+2026-01-12 22:50:03 [background-preinit] INFO  o.h.validator.internal.util.Version - HV000001: Hibernate Validator 9.0.1.Final
+2026-01-12 22:50:03 [main] INFO  c.e.l.LearningExamManagerApplication - Starting LearningExamManagerApplication using Java 23.0.2 with PID 49250 (/Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager/build/classes/java/main started by fumikun.wen in /Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager)
+2026-01-12 22:50:03 [main] DEBUG c.e.l.LearningExamManagerApplication - Running with Spring Boot v4.0.1, Spring v7.0.2
+2026-01-12 22:50:03 [main] INFO  c.e.l.LearningExamManagerApplication - No active profile set, falling back to 1 default profile: "default"
+2026-01-12 22:50:04 [main] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Bootstrapping Spring Data JPA repositories in DEFAULT mode.
+2026-01-12 22:50:04 [main] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Finished Spring Data repository scanning in 20 ms. Found 4 JPA repository interfaces.
+2026-01-12 22:50:04 [main] INFO  o.s.boot.tomcat.TomcatWebServer - Tomcat initialized with port 8080 (http)
+2026-01-12 22:50:04 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8080"]
+2026-01-12 22:50:04 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
+2026-01-12 22:50:04 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/11.0.15]
+2026-01-12 22:50:04 [main] INFO  o.s.b.w.c.s.WebApplicationContextInitializer - Root WebApplicationContext: initialization completed in 626 ms
+2026-01-12 22:50:04 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Starting...
+2026-01-12 22:50:04 [main] INFO  com.zaxxer.hikari.pool.HikariPool - HikariPool-1 - Added connection com.mysql.cj.jdbc.ConnectionImpl@76e6c070
+2026-01-12 22:50:04 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Start completed.
+2026-01-12 22:50:04 [main] INFO  org.flywaydb.core.FlywayExecutor - Database: jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8 (MySQL 9.3)
+2026-01-12 22:50:04 [main] WARN  o.f.c.i.database.base.Database - Using MySQL 9.3 which is newer than the version Flyway has been verified with. The latest verified version of MySQL is 8.1.
+2026-01-12 22:50:04 [main] INFO  o.f.core.internal.command.DbValidate - Successfully validated 2 migrations (execution time 00:00.020s)
+2026-01-12 22:50:04 [main] INFO  o.f.core.internal.command.DbMigrate - Current version of schema `learning_exam_manager`: 2
+2026-01-12 22:50:04 [main] INFO  o.f.core.internal.command.DbMigrate - Schema `learning_exam_manager` is up to date. No migration necessary.
+2026-01-12 22:50:04 [main] INFO  org.hibernate.orm.jpa - HHH008540: Processing PersistenceUnitInfo [name: default]
+2026-01-12 22:50:04 [main] INFO  org.hibernate.orm.core - HHH000001: Hibernate ORM core version 7.2.0.Final
+2026-01-12 22:50:05 [main] INFO  o.s.o.j.p.SpringPersistenceUnitInfo - No LoadTimeWeaver setup: ignoring JPA class transformer
+2026-01-12 22:50:05 [main] WARN  org.hibernate.orm.deprecation - HHH90000025: MySQLDialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
+2026-01-12 22:50:05 [main] INFO  o.hibernate.orm.connections.pooling - HHH10001005: Database info:
+	Database JDBC URL [jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8]
+	Database driver: MySQL Connector/J
+	Database dialect: MySQLDialect
+	Database version: 9.3
+	Default catalog/schema: learning_exam_manager/undefined
+	Autocommit mode: undefined/unknown
+	Isolation level: REPEATABLE_READ [default REPEATABLE_READ]
+	JDBC fetch size: none
+	Pool: DataSourceConnectionProvider
+	Minimum pool size: undefined/unknown
+	Maximum pool size: undefined/unknown
+2026-01-12 22:50:05 [main] INFO  org.hibernate.orm.core - HHH000489: No JTA platform available (set 'hibernate.transaction.jta.platform' to enable JTA platform integration)
+2026-01-12 22:50:05 [main] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Initialized JPA EntityManagerFactory for persistence unit 'default'
+2026-01-12 22:50:05 [main] INFO  o.s.d.j.r.q.QueryEnhancerFactories - Hibernate is in classpath; If applicable, HQL parser will be used.
+2026-01-12 22:50:06 [main] WARN  o.s.b.j.a.JpaBaseConfiguration$JpaWebConfiguration - spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering. Explicitly configure spring.jpa.open-in-view to disable this warning
+2026-01-12 22:50:06 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8080"]
+2026-01-12 22:50:06 [main] INFO  o.s.boot.tomcat.TomcatWebServer - Tomcat started on port 8080 (http) with context path '/'
+2026-01-12 22:50:06 [main] INFO  c.e.l.LearningExamManagerApplication - Started LearningExamManagerApplication in 2.873 seconds (process running for 3.049)
+2026-01-12 22:50:09 [http-nio-8080-exec-1] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
+2026-01-12 22:50:09 [http-nio-8080-exec-1] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
+2026-01-12 22:50:09 [http-nio-8080-exec-1] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 3 ms
+2026-01-12 22:50:09 [http-nio-8080-exec-1] DEBUG c.e.l.controller.SubjectController - 科目一覧を表示します: keyword=, page=0, size=10
+2026-01-12 22:50:09 [http-nio-8080-exec-1] DEBUG c.e.l.service.SubjectService - 科目一覧をページングして取得します
+2026-01-12 22:50:09 [http-nio-8080-exec-1] INFO  c.e.l.service.SubjectService - 科目を11件取得しました
+2026-01-12 22:50:09 [http-nio-8080-exec-1] INFO  c.e.l.controller.SubjectController - 科目一覧を表示しました: totalPages=2, totalItems=11, pageSize=10
+2026-01-12 22:50:13 [http-nio-8080-exec-3] DEBUG c.e.l.controller.StudyItemController - 学習項目一覧を表示します: keyword=null, subjectId=null, page=0, size=10
+2026-01-12 22:50:13 [http-nio-8080-exec-3] DEBUG c.e.l.service.SubjectService - すべての科目を取得します
+2026-01-12 22:50:13 [http-nio-8080-exec-3] INFO  c.e.l.service.SubjectService - 科目を11件取得しました
+2026-01-12 22:50:13 [http-nio-8080-exec-3] INFO  c.e.l.controller.StudyItemController - 学習項目一覧を表示しました: totalPages=10, totalItems=100, pageSize=10
+2026-01-12 22:50:20 [http-nio-8080-exec-5] DEBUG c.e.l.controller.StudyItemController - 学習項目一覧を表示します: keyword=, subjectId=null, page=2, size=10
+2026-01-12 22:50:20 [http-nio-8080-exec-5] DEBUG c.e.l.service.SubjectService - すべての科目を取得します
+2026-01-12 22:50:20 [http-nio-8080-exec-5] INFO  c.e.l.service.SubjectService - 科目を11件取得しました
+2026-01-12 22:50:20 [http-nio-8080-exec-5] INFO  c.e.l.controller.StudyItemController - 学習項目一覧を表示しました: totalPages=10, totalItems=100, pageSize=10
+2026-01-12 22:50:25 [http-nio-8080-exec-7] DEBUG c.e.l.controller.StudyItemController - 学習項目一覧を表示します: keyword=, subjectId=null, page=6, size=10
+2026-01-12 22:50:25 [http-nio-8080-exec-7] DEBUG c.e.l.service.SubjectService - すべての科目を取得します
+2026-01-12 22:50:25 [http-nio-8080-exec-7] INFO  c.e.l.service.SubjectService - 科目を11件取得しました
+2026-01-12 22:50:25 [http-nio-8080-exec-7] INFO  c.e.l.controller.StudyItemController - 学習項目一覧を表示しました: totalPages=10, totalItems=100, pageSize=10
+2026-01-12 22:51:03 [http-nio-8080-exec-9] DEBUG c.e.l.controller.StudyItemController - 学習項目一覧を表示します: keyword=, subjectId=null, page=0, size=10
+2026-01-12 22:51:03 [http-nio-8080-exec-9] DEBUG c.e.l.service.SubjectService - すべての科目を取得します
+2026-01-12 22:51:03 [http-nio-8080-exec-9] INFO  c.e.l.service.SubjectService - 科目を11件取得しました
+2026-01-12 22:51:03 [http-nio-8080-exec-9] INFO  c.e.l.controller.StudyItemController - 学習項目一覧を表示しました: totalPages=10, totalItems=100, pageSize=10
+2026-01-12 22:58:07 [SpringApplicationShutdownHook] INFO  o.s.boot.tomcat.GracefulShutdown - Commencing graceful shutdown. Waiting for active requests to complete
+2026-01-12 22:58:07 [tomcat-shutdown] INFO  o.s.boot.tomcat.GracefulShutdown - Graceful shutdown complete
+2026-01-12 22:58:07 [SpringApplicationShutdownHook] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Closing JPA EntityManagerFactory for persistence unit 'default'
+2026-01-12 22:58:07 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown initiated...
+2026-01-12 22:58:07 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown completed.
+2026-01-12 22:58:26 [background-preinit] INFO  o.h.validator.internal.util.Version - HV000001: Hibernate Validator 9.0.1.Final
+2026-01-12 22:58:26 [main] INFO  c.e.l.LearningExamManagerApplication - Starting LearningExamManagerApplication using Java 23.0.2 with PID 53728 (/Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager/build/classes/java/main started by fumikun.wen in /Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager)
+2026-01-12 22:58:26 [main] DEBUG c.e.l.LearningExamManagerApplication - Running with Spring Boot v4.0.1, Spring v7.0.2
+2026-01-12 22:58:26 [main] INFO  c.e.l.LearningExamManagerApplication - No active profile set, falling back to 1 default profile: "default"
+2026-01-12 22:58:26 [main] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Bootstrapping Spring Data JPA repositories in DEFAULT mode.
+2026-01-12 22:58:26 [main] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Finished Spring Data repository scanning in 20 ms. Found 4 JPA repository interfaces.
+2026-01-12 22:58:26 [main] INFO  o.s.boot.tomcat.TomcatWebServer - Tomcat initialized with port 8080 (http)
+2026-01-12 22:58:26 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8080"]
+2026-01-12 22:58:26 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
+2026-01-12 22:58:26 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/11.0.15]
+2026-01-12 22:58:26 [main] INFO  o.s.b.w.c.s.WebApplicationContextInitializer - Root WebApplicationContext: initialization completed in 523 ms
+2026-01-12 22:58:26 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Starting...
+2026-01-12 22:58:26 [main] INFO  com.zaxxer.hikari.pool.HikariPool - HikariPool-1 - Added connection com.mysql.cj.jdbc.ConnectionImpl@4f26425b
+2026-01-12 22:58:26 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Start completed.
+2026-01-12 22:58:26 [main] INFO  org.flywaydb.core.FlywayExecutor - Database: jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8 (MySQL 9.3)
+2026-01-12 22:58:26 [main] WARN  o.f.c.i.database.base.Database - Using MySQL 9.3 which is newer than the version Flyway has been verified with. The latest verified version of MySQL is 8.1.
+2026-01-12 22:58:26 [main] INFO  o.f.core.internal.command.DbValidate - Successfully validated 2 migrations (execution time 00:00.019s)
+2026-01-12 22:58:26 [main] INFO  o.f.core.internal.command.DbMigrate - Current version of schema `learning_exam_manager`: 2
+2026-01-12 22:58:26 [main] INFO  o.f.core.internal.command.DbMigrate - Schema `learning_exam_manager` is up to date. No migration necessary.
+2026-01-12 22:58:26 [main] INFO  org.hibernate.orm.jpa - HHH008540: Processing PersistenceUnitInfo [name: default]
+2026-01-12 22:58:27 [main] INFO  org.hibernate.orm.core - HHH000001: Hibernate ORM core version 7.2.0.Final
+2026-01-12 22:58:27 [main] INFO  o.s.o.j.p.SpringPersistenceUnitInfo - No LoadTimeWeaver setup: ignoring JPA class transformer
+2026-01-12 22:58:27 [main] WARN  org.hibernate.orm.deprecation - HHH90000025: MySQLDialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
+2026-01-12 22:58:27 [main] INFO  o.hibernate.orm.connections.pooling - HHH10001005: Database info:
+	Database JDBC URL [jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8]
+	Database driver: MySQL Connector/J
+	Database dialect: MySQLDialect
+	Database version: 9.3
+	Default catalog/schema: learning_exam_manager/undefined
+	Autocommit mode: undefined/unknown
+	Isolation level: REPEATABLE_READ [default REPEATABLE_READ]
+	JDBC fetch size: none
+	Pool: DataSourceConnectionProvider
+	Minimum pool size: undefined/unknown
+	Maximum pool size: undefined/unknown
+2026-01-12 22:58:27 [main] INFO  org.hibernate.orm.core - HHH000489: No JTA platform available (set 'hibernate.transaction.jta.platform' to enable JTA platform integration)
+2026-01-12 22:58:27 [main] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Initialized JPA EntityManagerFactory for persistence unit 'default'
+2026-01-12 22:58:27 [main] INFO  o.s.d.j.r.q.QueryEnhancerFactories - Hibernate is in classpath; If applicable, HQL parser will be used.
+2026-01-12 22:58:28 [main] WARN  o.s.b.j.a.JpaBaseConfiguration$JpaWebConfiguration - spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering. Explicitly configure spring.jpa.open-in-view to disable this warning
+2026-01-12 22:58:28 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8080"]
+2026-01-12 22:58:28 [main] INFO  o.s.boot.tomcat.TomcatWebServer - Tomcat started on port 8080 (http) with context path '/'
+2026-01-12 22:58:28 [main] INFO  c.e.l.LearningExamManagerApplication - Started LearningExamManagerApplication in 2.609 seconds (process running for 2.799)
+2026-01-12 22:58:29 [http-nio-8080-exec-1] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
+2026-01-12 22:58:29 [http-nio-8080-exec-1] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
+2026-01-12 22:58:29 [http-nio-8080-exec-1] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 1 ms
+2026-01-12 22:58:29 [http-nio-8080-exec-1] DEBUG c.e.l.controller.StudyItemController - 学習項目一覧を表示します: keyword=, subjectId=null, page=0, size=10
+2026-01-12 22:58:29 [http-nio-8080-exec-1] DEBUG c.e.l.service.SubjectService - すべての科目を取得します
+2026-01-12 22:58:29 [http-nio-8080-exec-1] INFO  c.e.l.service.SubjectService - 科目を11件取得しました
+2026-01-12 22:58:29 [http-nio-8080-exec-1] INFO  c.e.l.controller.StudyItemController - 学習項目一覧を表示しました: totalPages=10, totalItems=100, pageSize=10
+2026-01-12 22:58:32 [http-nio-8080-exec-2] DEBUG c.e.l.controller.ExamController - 試験一覧を表示します: keyword=null, page=0, size=10
+2026-01-12 22:58:32 [http-nio-8080-exec-2] DEBUG c.e.l.service.ExamService - 試験一覧をページングして取得します
+2026-01-12 22:58:32 [http-nio-8080-exec-2] INFO  c.e.l.service.ExamService - 試験を18件取得しました
+2026-01-12 22:58:32 [http-nio-8080-exec-2] INFO  c.e.l.controller.ExamController - 試験一覧を表示しました: totalPages=2, totalItems=18, pageSize=10
+2026-01-12 22:58:36 [http-nio-8080-exec-4] DEBUG c.e.l.controller.ExamController - 試験一覧を表示します: keyword=, page=1, size=10
+2026-01-12 22:58:36 [http-nio-8080-exec-4] DEBUG c.e.l.service.ExamService - 試験一覧をページングして取得します
+2026-01-12 22:58:36 [http-nio-8080-exec-4] INFO  c.e.l.service.ExamService - 試験を18件取得しました
+2026-01-12 22:58:36 [http-nio-8080-exec-4] INFO  c.e.l.controller.ExamController - 試験一覧を表示しました: totalPages=2, totalItems=18, pageSize=10
+2026-01-12 22:59:02 [http-nio-8080-exec-6] DEBUG c.e.l.controller.ExamController - 試験登録画面を表示します
+2026-01-12 22:59:02 [http-nio-8080-exec-6] DEBUG c.e.l.service.SubjectService - すべての科目を取得します
+2026-01-12 22:59:02 [http-nio-8080-exec-6] INFO  c.e.l.service.SubjectService - 科目を11件取得しました
+2026-01-12 22:59:02 [http-nio-8080-exec-6] INFO  c.e.l.controller.ExamController - 試験登録画面を表示しました
+2026-01-12 22:59:13 [http-nio-8080-exec-8] INFO  c.e.l.service.ExamService - 新しい試験を作成します: java
+2026-01-12 22:59:13 [http-nio-8080-exec-8] INFO  c.e.l.service.ExamService - 試験を作成しました: ID=19, 試験名=java
+2026-01-12 22:59:13 [http-nio-8080-exec-8] INFO  c.e.l.controller.ExamController - 試験を登録しました: 試験名=java
+2026-01-12 22:59:13 [http-nio-8080-exec-9] DEBUG c.e.l.controller.ExamController - 試験一覧を表示します: keyword=null, page=0, size=10
+2026-01-12 22:59:13 [http-nio-8080-exec-9] DEBUG c.e.l.service.ExamService - 試験一覧をページングして取得します
+2026-01-12 22:59:13 [http-nio-8080-exec-9] INFO  c.e.l.service.ExamService - 試験を19件取得しました
+2026-01-12 22:59:13 [http-nio-8080-exec-9] INFO  c.e.l.controller.ExamController - 試験一覧を表示しました: totalPages=2, totalItems=19, pageSize=10
+2026-01-12 23:00:06 [http-nio-8080-exec-1] DEBUG c.e.l.controller.ExamController - 試験一覧を表示します: keyword=, page=1, size=10
+2026-01-12 23:00:06 [http-nio-8080-exec-1] DEBUG c.e.l.service.ExamService - 試験一覧をページングして取得します
+2026-01-12 23:00:06 [http-nio-8080-exec-1] INFO  c.e.l.service.ExamService - 試験を19件取得しました
+2026-01-12 23:00:06 [http-nio-8080-exec-1] INFO  c.e.l.controller.ExamController - 試験一覧を表示しました: totalPages=2, totalItems=19, pageSize=10
+2026-01-12 23:00:11 [http-nio-8080-exec-3] WARN  c.e.l.controller.ExamController - 試験を削除します: ID=19
+2026-01-12 23:00:11 [http-nio-8080-exec-3] WARN  c.e.l.service.ExamService - 試験を削除します: ID=19
+2026-01-12 23:00:11 [http-nio-8080-exec-3] INFO  c.e.l.service.ExamService - 試験を削除しました: ID=19
+2026-01-12 23:00:11 [http-nio-8080-exec-3] INFO  c.e.l.controller.ExamController - 試験を削除しました: ID=19
+2026-01-12 23:00:11 [http-nio-8080-exec-4] DEBUG c.e.l.controller.ExamController - 試験一覧を表示します: keyword=null, page=0, size=10
+2026-01-12 23:00:11 [http-nio-8080-exec-4] DEBUG c.e.l.service.ExamService - 試験一覧をページングして取得します
+2026-01-12 23:00:11 [http-nio-8080-exec-4] INFO  c.e.l.service.ExamService - 試験を18件取得しました
+2026-01-12 23:00:11 [http-nio-8080-exec-4] INFO  c.e.l.controller.ExamController - 試験一覧を表示しました: totalPages=2, totalItems=18, pageSize=10
+2026-01-12 23:03:15 [background-preinit] INFO  o.h.validator.internal.util.Version - HV000001: Hibernate Validator 9.0.1.Final
+2026-01-12 23:03:15 [Test worker] INFO  c.e.l.LearningExamManagerApplicationTests - Starting LearningExamManagerApplicationTests using Java 23.0.2 with PID 56272 (started by fumikun.wen in /Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager)
+2026-01-12 23:03:15 [Test worker] DEBUG c.e.l.LearningExamManagerApplicationTests - Running with Spring Boot v4.0.1, Spring v7.0.2
+2026-01-12 23:03:15 [Test worker] INFO  c.e.l.LearningExamManagerApplicationTests - No active profile set, falling back to 1 default profile: "default"
+2026-01-12 23:03:16 [Test worker] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Bootstrapping Spring Data JPA repositories in DEFAULT mode.
+2026-01-12 23:03:16 [Test worker] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Finished Spring Data repository scanning in 32 ms. Found 4 JPA repository interfaces.
+2026-01-12 23:03:16 [Test worker] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Starting...
+2026-01-12 23:03:16 [Test worker] INFO  com.zaxxer.hikari.pool.HikariPool - HikariPool-1 - Added connection com.mysql.cj.jdbc.ConnectionImpl@38ebc866
+2026-01-12 23:03:16 [Test worker] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Start completed.
+2026-01-12 23:03:16 [Test worker] INFO  org.flywaydb.core.FlywayExecutor - Database: jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8 (MySQL 9.3)
+2026-01-12 23:03:16 [Test worker] WARN  o.f.c.i.database.base.Database - Using MySQL 9.3 which is newer than the version Flyway has been verified with. The latest verified version of MySQL is 8.1.
+2026-01-12 23:03:16 [Test worker] INFO  o.f.core.internal.command.DbValidate - Successfully validated 2 migrations (execution time 00:00.031s)
+2026-01-12 23:03:16 [Test worker] INFO  o.f.core.internal.command.DbMigrate - Current version of schema `learning_exam_manager`: 2
+2026-01-12 23:03:16 [Test worker] INFO  o.f.core.internal.command.DbMigrate - Schema `learning_exam_manager` is up to date. No migration necessary.
+2026-01-12 23:03:17 [Test worker] INFO  org.hibernate.orm.jpa - HHH008540: Processing PersistenceUnitInfo [name: default]
+2026-01-12 23:03:17 [Test worker] INFO  org.hibernate.orm.core - HHH000001: Hibernate ORM core version 7.2.0.Final
+2026-01-12 23:03:17 [Test worker] INFO  o.s.o.j.p.SpringPersistenceUnitInfo - No LoadTimeWeaver setup: ignoring JPA class transformer
+2026-01-12 23:03:17 [Test worker] WARN  org.hibernate.orm.deprecation - HHH90000025: MySQLDialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
+2026-01-12 23:03:17 [Test worker] INFO  o.hibernate.orm.connections.pooling - HHH10001005: Database info:
+	Database JDBC URL [jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8]
+	Database driver: MySQL Connector/J
+	Database dialect: MySQLDialect
+	Database version: 9.3
+	Default catalog/schema: learning_exam_manager/undefined
+	Autocommit mode: undefined/unknown
+	Isolation level: REPEATABLE_READ [default REPEATABLE_READ]
+	JDBC fetch size: none
+	Pool: DataSourceConnectionProvider
+	Minimum pool size: undefined/unknown
+	Maximum pool size: undefined/unknown
+2026-01-12 23:03:17 [Test worker] INFO  org.hibernate.orm.core - HHH000489: No JTA platform available (set 'hibernate.transaction.jta.platform' to enable JTA platform integration)
+2026-01-12 23:03:17 [Test worker] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Initialized JPA EntityManagerFactory for persistence unit 'default'
+2026-01-12 23:03:17 [Test worker] INFO  o.s.d.j.r.q.QueryEnhancerFactories - Hibernate is in classpath; If applicable, HQL parser will be used.
+2026-01-12 23:03:18 [Test worker] WARN  o.s.b.j.a.JpaBaseConfiguration$JpaWebConfiguration - spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering. Explicitly configure spring.jpa.open-in-view to disable this warning
+2026-01-12 23:03:18 [Test worker] INFO  c.e.l.LearningExamManagerApplicationTests - Started LearningExamManagerApplicationTests in 2.962 seconds (process running for 3.539)
+2026-01-12 23:03:18 [SpringApplicationShutdownHook] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Closing JPA EntityManagerFactory for persistence unit 'default'
+2026-01-12 23:03:18 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown initiated...
+2026-01-12 23:03:18 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown completed.
+2026-01-12 23:03:44 [SpringApplicationShutdownHook] INFO  o.s.boot.tomcat.GracefulShutdown - Commencing graceful shutdown. Waiting for active requests to complete
+2026-01-12 23:03:44 [tomcat-shutdown] INFO  o.s.boot.tomcat.GracefulShutdown - Graceful shutdown complete
+2026-01-12 23:03:44 [SpringApplicationShutdownHook] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Closing JPA EntityManagerFactory for persistence unit 'default'
+2026-01-12 23:03:44 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown initiated...
+2026-01-12 23:03:44 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown completed.
+2026-01-12 23:03:49 [background-preinit] INFO  o.h.validator.internal.util.Version - HV000001: Hibernate Validator 9.0.1.Final
+2026-01-12 23:03:49 [main] INFO  c.e.l.LearningExamManagerApplication - Starting LearningExamManagerApplication using Java 23.0.2 with PID 56825 (/Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager/build/classes/java/main started by fumikun.wen in /Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager)
+2026-01-12 23:03:49 [main] DEBUG c.e.l.LearningExamManagerApplication - Running with Spring Boot v4.0.1, Spring v7.0.2
+2026-01-12 23:03:49 [main] INFO  c.e.l.LearningExamManagerApplication - No active profile set, falling back to 1 default profile: "default"
+2026-01-12 23:03:49 [main] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Bootstrapping Spring Data JPA repositories in DEFAULT mode.
+2026-01-12 23:03:49 [main] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Finished Spring Data repository scanning in 19 ms. Found 4 JPA repository interfaces.
+2026-01-12 23:03:49 [main] INFO  o.s.boot.tomcat.TomcatWebServer - Tomcat initialized with port 8080 (http)
+2026-01-12 23:03:49 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8080"]
+2026-01-12 23:03:49 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
+2026-01-12 23:03:49 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/11.0.15]
+2026-01-12 23:03:49 [main] INFO  o.s.b.w.c.s.WebApplicationContextInitializer - Root WebApplicationContext: initialization completed in 462 ms
+2026-01-12 23:03:49 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Starting...
+2026-01-12 23:03:49 [main] INFO  com.zaxxer.hikari.pool.HikariPool - HikariPool-1 - Added connection com.mysql.cj.jdbc.ConnectionImpl@4f26425b
+2026-01-12 23:03:49 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Start completed.
+2026-01-12 23:03:49 [main] INFO  org.flywaydb.core.FlywayExecutor - Database: jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8 (MySQL 9.3)
+2026-01-12 23:03:49 [main] WARN  o.f.c.i.database.base.Database - Using MySQL 9.3 which is newer than the version Flyway has been verified with. The latest verified version of MySQL is 8.1.
+2026-01-12 23:03:50 [main] INFO  o.f.core.internal.command.DbValidate - Successfully validated 2 migrations (execution time 00:00.021s)
+2026-01-12 23:03:50 [main] INFO  o.f.core.internal.command.DbMigrate - Current version of schema `learning_exam_manager`: 2
+2026-01-12 23:03:50 [main] INFO  o.f.core.internal.command.DbMigrate - Schema `learning_exam_manager` is up to date. No migration necessary.
+2026-01-12 23:03:50 [main] INFO  org.hibernate.orm.jpa - HHH008540: Processing PersistenceUnitInfo [name: default]
+2026-01-12 23:03:50 [main] INFO  org.hibernate.orm.core - HHH000001: Hibernate ORM core version 7.2.0.Final
+2026-01-12 23:03:50 [main] INFO  o.s.o.j.p.SpringPersistenceUnitInfo - No LoadTimeWeaver setup: ignoring JPA class transformer
+2026-01-12 23:03:50 [main] WARN  org.hibernate.orm.deprecation - HHH90000025: MySQLDialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
+2026-01-12 23:03:50 [main] INFO  o.hibernate.orm.connections.pooling - HHH10001005: Database info:
+	Database JDBC URL [jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8]
+	Database driver: MySQL Connector/J
+	Database dialect: MySQLDialect
+	Database version: 9.3
+	Default catalog/schema: learning_exam_manager/undefined
+	Autocommit mode: undefined/unknown
+	Isolation level: REPEATABLE_READ [default REPEATABLE_READ]
+	JDBC fetch size: none
+	Pool: DataSourceConnectionProvider
+	Minimum pool size: undefined/unknown
+	Maximum pool size: undefined/unknown
+2026-01-12 23:03:50 [main] INFO  org.hibernate.orm.core - HHH000489: No JTA platform available (set 'hibernate.transaction.jta.platform' to enable JTA platform integration)
+2026-01-12 23:03:50 [main] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Initialized JPA EntityManagerFactory for persistence unit 'default'
+2026-01-12 23:03:50 [main] INFO  o.s.d.j.r.q.QueryEnhancerFactories - Hibernate is in classpath; If applicable, HQL parser will be used.
+2026-01-12 23:03:51 [main] WARN  o.s.b.j.a.JpaBaseConfiguration$JpaWebConfiguration - spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering. Explicitly configure spring.jpa.open-in-view to disable this warning
+2026-01-12 23:03:51 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8080"]
+2026-01-12 23:03:51 [main] INFO  o.s.boot.tomcat.TomcatWebServer - Tomcat started on port 8080 (http) with context path '/'
+2026-01-12 23:03:51 [main] INFO  c.e.l.LearningExamManagerApplication - Started LearningExamManagerApplication in 2.413 seconds (process running for 2.594)
+2026-01-12 23:04:00 [http-nio-8080-exec-1] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
+2026-01-12 23:04:00 [http-nio-8080-exec-1] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
+2026-01-12 23:04:00 [http-nio-8080-exec-1] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 3 ms
+2026-01-12 23:04:00 [http-nio-8080-exec-1] DEBUG c.e.l.c.ExamResultController - 試験結果一覧を表示します: keyword=null, page=0, size=10
+2026-01-12 23:04:00 [http-nio-8080-exec-1] DEBUG c.e.l.service.ExamResultService - 試験結果一覧をページングして取得します
+2026-01-12 23:04:00 [http-nio-8080-exec-1] INFO  c.e.l.service.ExamResultService - 試験結果を64件取得しました
+2026-01-12 23:04:00 [http-nio-8080-exec-1] INFO  c.e.l.c.ExamResultController - 試験結果一覧を表示しました: totalPages=7, totalItems=64, pageSize=10
+2026-01-12 23:04:37 [http-nio-8080-exec-3] DEBUG c.e.l.c.ExamResultController - 試験結果登録画面を表示します
+2026-01-12 23:04:37 [http-nio-8080-exec-3] DEBUG c.e.l.service.ExamService - すべての試験を取得します
+2026-01-12 23:04:37 [http-nio-8080-exec-3] INFO  c.e.l.service.ExamService - 試験を18件取得しました
+2026-01-12 23:04:37 [http-nio-8080-exec-3] INFO  c.e.l.c.ExamResultController - 試験結果登録画面を表示しました
+2026-01-12 23:04:44 [http-nio-8080-exec-5] INFO  c.e.l.service.ExamResultService - 新しい試験結果を作成します: 試験ID=5, 得点=50
+2026-01-12 23:04:44 [http-nio-8080-exec-5] INFO  c.e.l.service.ExamResultService - 試験結果を作成しました: ID=65, 試験名=Spring Boot実践テスト, 得点=50, 合否=false
+2026-01-12 23:04:44 [http-nio-8080-exec-5] INFO  c.e.l.c.ExamResultController - 試験結果を登録しました: 試験ID=5, 得点=50
+2026-01-12 23:04:44 [http-nio-8080-exec-6] DEBUG c.e.l.c.ExamResultController - 試験結果一覧を表示します: keyword=null, page=0, size=10
+2026-01-12 23:04:44 [http-nio-8080-exec-6] DEBUG c.e.l.service.ExamResultService - 試験結果一覧をページングして取得します
+2026-01-12 23:04:44 [http-nio-8080-exec-6] INFO  c.e.l.service.ExamResultService - 試験結果を65件取得しました
+2026-01-12 23:04:44 [http-nio-8080-exec-6] INFO  c.e.l.c.ExamResultController - 試験結果一覧を表示しました: totalPages=7, totalItems=65, pageSize=10
+2026-01-12 23:05:08 [http-nio-8080-exec-8] DEBUG c.e.l.c.ExamResultController - 試験結果一覧を表示します: keyword=, page=6, size=10
+2026-01-12 23:05:08 [http-nio-8080-exec-8] DEBUG c.e.l.service.ExamResultService - 試験結果一覧をページングして取得します
+2026-01-12 23:05:08 [http-nio-8080-exec-8] INFO  c.e.l.service.ExamResultService - 試験結果を65件取得しました
+2026-01-12 23:05:08 [http-nio-8080-exec-8] INFO  c.e.l.c.ExamResultController - 試験結果一覧を表示しました: totalPages=7, totalItems=65, pageSize=10
+2026-01-12 23:05:11 [http-nio-8080-exec-9] DEBUG c.e.l.c.ExamResultController - 試験結果一覧を表示します: keyword=, page=5, size=10
+2026-01-12 23:05:11 [http-nio-8080-exec-9] DEBUG c.e.l.service.ExamResultService - 試験結果一覧をページングして取得します
+2026-01-12 23:05:11 [http-nio-8080-exec-9] INFO  c.e.l.service.ExamResultService - 試験結果を65件取得しました
+2026-01-12 23:05:11 [http-nio-8080-exec-9] INFO  c.e.l.c.ExamResultController - 試験結果一覧を表示しました: totalPages=7, totalItems=65, pageSize=10
+2026-01-12 23:05:16 [http-nio-8080-exec-1] DEBUG c.e.l.c.ExamResultController - 試験結果一覧を表示します: keyword=, page=1, size=10
+2026-01-12 23:05:16 [http-nio-8080-exec-1] DEBUG c.e.l.service.ExamResultService - 試験結果一覧をページングして取得します
+2026-01-12 23:05:16 [http-nio-8080-exec-1] INFO  c.e.l.service.ExamResultService - 試験結果を65件取得しました
+2026-01-12 23:05:16 [http-nio-8080-exec-1] INFO  c.e.l.c.ExamResultController - 試験結果一覧を表示しました: totalPages=7, totalItems=65, pageSize=10
+2026-01-12 23:05:18 [http-nio-8080-exec-3] DEBUG c.e.l.c.ExamResultController - 試験結果一覧を表示します: keyword=, page=0, size=10
+2026-01-12 23:05:18 [http-nio-8080-exec-3] DEBUG c.e.l.service.ExamResultService - 試験結果一覧をページングして取得します
+2026-01-12 23:05:18 [http-nio-8080-exec-3] INFO  c.e.l.service.ExamResultService - 試験結果を65件取得しました
+2026-01-12 23:05:18 [http-nio-8080-exec-3] INFO  c.e.l.c.ExamResultController - 試験結果一覧を表示しました: totalPages=7, totalItems=65, pageSize=10
+2026-01-12 23:05:33 [http-nio-8080-exec-5] WARN  c.e.l.c.ExamResultController - 試験結果を削除します: ID=65
+2026-01-12 23:05:33 [http-nio-8080-exec-5] WARN  c.e.l.service.ExamResultService - 試験結果を削除します: ID=65
+2026-01-12 23:05:33 [http-nio-8080-exec-5] INFO  c.e.l.service.ExamResultService - 試験結果を削除しました: ID=65
+2026-01-12 23:05:33 [http-nio-8080-exec-5] INFO  c.e.l.c.ExamResultController - 試験結果を削除しました: ID=65
+2026-01-12 23:05:33 [http-nio-8080-exec-6] DEBUG c.e.l.c.ExamResultController - 試験結果一覧を表示します: keyword=null, page=0, size=10
+2026-01-12 23:05:33 [http-nio-8080-exec-6] DEBUG c.e.l.service.ExamResultService - 試験結果一覧をページングして取得します
+2026-01-12 23:05:33 [http-nio-8080-exec-6] INFO  c.e.l.service.ExamResultService - 試験結果を64件取得しました
+2026-01-12 23:05:33 [http-nio-8080-exec-6] INFO  c.e.l.c.ExamResultController - 試験結果一覧を表示しました: totalPages=7, totalItems=64, pageSize=10

--- a/logs/application.log
+++ b/logs/application.log
@@ -1,23 +1,228 @@
-2026-01-12 22:15:10 [background-preinit] INFO  o.h.validator.internal.util.Version - HV000001: Hibernate Validator 9.0.1.Final
-2026-01-12 22:15:10 [Test worker] INFO  c.e.l.LearningExamManagerApplicationTests - Starting LearningExamManagerApplicationTests using Java 23.0.2 with PID 30036 (started by fumikun.wen in /Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager)
-2026-01-12 22:15:10 [Test worker] DEBUG c.e.l.LearningExamManagerApplicationTests - Running with Spring Boot v4.0.1, Spring v7.0.2
-2026-01-12 22:15:10 [Test worker] INFO  c.e.l.LearningExamManagerApplicationTests - No active profile set, falling back to 1 default profile: "default"
-2026-01-12 22:15:10 [Test worker] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Bootstrapping Spring Data JPA repositories in DEFAULT mode.
-2026-01-12 22:15:10 [Test worker] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Finished Spring Data repository scanning in 22 ms. Found 4 JPA repository interfaces.
-2026-01-12 22:15:11 [Test worker] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Starting...
-2026-01-12 22:15:11 [Test worker] INFO  com.zaxxer.hikari.pool.HikariPool - HikariPool-1 - Added connection com.mysql.cj.jdbc.ConnectionImpl@53e4a19e
-2026-01-12 22:15:11 [Test worker] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Start completed.
-2026-01-12 22:15:11 [Test worker] INFO  org.flywaydb.core.FlywayExecutor - Database: jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8 (MySQL 9.3)
-2026-01-12 22:15:11 [Test worker] WARN  o.f.c.i.database.base.Database - Using MySQL 9.3 which is newer than the version Flyway has been verified with. The latest verified version of MySQL is 8.1.
-2026-01-12 22:15:11 [Test worker] INFO  o.f.core.internal.command.DbValidate - Successfully validated 2 migrations (execution time 00:00.032s)
-2026-01-12 22:15:11 [Test worker] INFO  o.f.core.internal.command.DbMigrate - Current version of schema `learning_exam_manager`: 2
-2026-01-12 22:15:11 [Test worker] INFO  o.f.core.internal.command.DbMigrate - Schema `learning_exam_manager` is up to date. No migration necessary.
-2026-01-12 22:15:11 [Test worker] INFO  org.hibernate.orm.jpa - HHH008540: Processing PersistenceUnitInfo [name: default]
-2026-01-12 22:15:11 [Test worker] INFO  org.hibernate.orm.core - HHH000001: Hibernate ORM core version 7.2.0.Final
-2026-01-12 22:15:11 [Test worker] INFO  o.s.o.j.p.SpringPersistenceUnitInfo - No LoadTimeWeaver setup: ignoring JPA class transformer
-2026-01-12 22:15:11 [Test worker] WARN  org.hibernate.orm.deprecation - HHH90000025: MySQLDialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
-2026-01-12 22:15:11 [Test worker] INFO  o.hibernate.orm.connections.pooling - HHH10001005: Database info:
-	Database JDBC URL [jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8]
+2026-01-13 22:25:04 [background-preinit] INFO  o.h.validator.internal.util.Version - HV000001: Hibernate Validator 9.0.1.Final
+2026-01-13 22:25:04 [main] INFO  c.e.l.LearningExamManagerApplication - Starting LearningExamManagerApplication using Java 23.0.2 with PID 6641 (/Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager/build/classes/java/main started by fumikun.wen in /Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager)
+2026-01-13 22:25:04 [main] DEBUG c.e.l.LearningExamManagerApplication - Running with Spring Boot v4.0.1, Spring v7.0.2
+2026-01-13 22:25:04 [main] INFO  c.e.l.LearningExamManagerApplication - No active profile set, falling back to 1 default profile: "default"
+2026-01-13 22:25:05 [main] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Bootstrapping Spring Data JPA repositories in DEFAULT mode.
+2026-01-13 22:25:05 [main] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Finished Spring Data repository scanning in 25 ms. Found 4 JPA repository interfaces.
+2026-01-13 22:25:05 [main] INFO  o.s.boot.tomcat.TomcatWebServer - Tomcat initialized with port 8080 (http)
+2026-01-13 22:25:05 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8080"]
+2026-01-13 22:25:05 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
+2026-01-13 22:25:05 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/11.0.15]
+2026-01-13 22:25:05 [main] INFO  o.s.b.w.c.s.WebApplicationContextInitializer - Root WebApplicationContext: initialization completed in 723 ms
+2026-01-13 22:25:05 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Starting...
+2026-01-13 22:25:06 [main] WARN  o.s.b.w.s.s.c.AnnotationConfigServletWebServerApplicationContext - Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'entityManagerFactory' defined in class path resource [org/springframework/boot/hibernate/autoconfigure/HibernateJpaConfiguration.class]: Failed to initialize dependency 'flywayInitializer' of LoadTimeWeaverAware bean 'entityManagerFactory': Error creating bean with name 'flywayInitializer' defined in class path resource [org/springframework/boot/flyway/autoconfigure/FlywayAutoConfiguration$FlywayConfiguration.class]: Unable to obtain connection from database: Public Key Retrieval is not allowed
+------------------------------------------------------------------------------
+SQL State  : 08001
+Error Code : 0
+Message    : Public Key Retrieval is not allowed
+
+2026-01-13 22:25:06 [main] INFO  o.a.catalina.core.StandardService - Stopping service [Tomcat]
+2026-01-13 22:25:06 [main] INFO  o.s.b.a.l.ConditionEvaluationReportLogger - 
+
+Error starting ApplicationContext. To display the condition evaluation report re-run your application with 'debug' enabled.
+2026-01-13 22:25:06 [main] ERROR o.s.boot.SpringApplication - Application run failed
+org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'entityManagerFactory' defined in class path resource [org/springframework/boot/hibernate/autoconfigure/HibernateJpaConfiguration.class]: Failed to initialize dependency 'flywayInitializer' of LoadTimeWeaverAware bean 'entityManagerFactory': Error creating bean with name 'flywayInitializer' defined in class path resource [org/springframework/boot/flyway/autoconfigure/FlywayAutoConfiguration$FlywayConfiguration.class]: Unable to obtain connection from database: Public Key Retrieval is not allowed
+------------------------------------------------------------------------------
+SQL State  : 08001
+Error Code : 0
+Message    : Public Key Retrieval is not allowed
+
+	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:322)
+	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:201)
+	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:976)
+	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:620)
+	at org.springframework.boot.web.server.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:143)
+	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:756)
+	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:445)
+	at org.springframework.boot.SpringApplication.run(SpringApplication.java:321)
+	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1365)
+	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1354)
+	at com.example.learning_exam_manager.LearningExamManagerApplication.main(LearningExamManagerApplication.java:10)
+Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'flywayInitializer' defined in class path resource [org/springframework/boot/flyway/autoconfigure/FlywayAutoConfiguration$FlywayConfiguration.class]: Unable to obtain connection from database: Public Key Retrieval is not allowed
+------------------------------------------------------------------------------
+SQL State  : 08001
+Error Code : 0
+Message    : Public Key Retrieval is not allowed
+
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1817)
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:603)
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:525)
+	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:333)
+	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:371)
+	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:331)
+	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:196)
+	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:309)
+	... 10 common frames omitted
+Caused by: org.flywaydb.core.internal.exception.sqlExceptions.FlywaySqlUnableToConnectToDbException: Unable to obtain connection from database: Public Key Retrieval is not allowed
+------------------------------------------------------------------------------
+SQL State  : 08001
+Error Code : 0
+Message    : Public Key Retrieval is not allowed
+
+	at org.flywaydb.core.internal.jdbc.JdbcUtils.openConnection(JdbcUtils.java:70)
+	at org.flywaydb.core.internal.jdbc.JdbcConnectionFactory.<init>(JdbcConnectionFactory.java:76)
+	at org.flywaydb.core.FlywayExecutor.execute(FlywayExecutor.java:142)
+	at org.flywaydb.core.Flyway.migrate(Flyway.java:186)
+	at org.springframework.boot.flyway.autoconfigure.FlywayMigrationInitializer.afterPropertiesSet(FlywayMigrationInitializer.java:67)
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1864)
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1813)
+	... 17 common frames omitted
+Caused by: java.sql.SQLNonTransientConnectionException: Public Key Retrieval is not allowed
+	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:102)
+	at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:114)
+	at com.mysql.cj.jdbc.ConnectionImpl.createNewIO(ConnectionImpl.java:840)
+	at com.mysql.cj.jdbc.ConnectionImpl.<init>(ConnectionImpl.java:416)
+	at com.mysql.cj.jdbc.ConnectionImpl.getInstance(ConnectionImpl.java:237)
+	at com.mysql.cj.jdbc.NonRegisteringDriver.connect(NonRegisteringDriver.java:180)
+	at com.zaxxer.hikari.util.DriverDataSource.getConnection(DriverDataSource.java:144)
+	at com.zaxxer.hikari.pool.PoolBase.newConnection(PoolBase.java:373)
+	at com.zaxxer.hikari.pool.PoolBase.newPoolEntry(PoolBase.java:210)
+	at com.zaxxer.hikari.pool.HikariPool.createPoolEntry(HikariPool.java:488)
+	at com.zaxxer.hikari.pool.HikariPool.checkFailFast(HikariPool.java:576)
+	at com.zaxxer.hikari.pool.HikariPool.<init>(HikariPool.java:97)
+	at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:111)
+	at org.flywaydb.core.internal.jdbc.JdbcUtils.openConnection(JdbcUtils.java:65)
+	... 23 common frames omitted
+Caused by: com.mysql.cj.exceptions.UnableToConnectException: Public Key Retrieval is not allowed
+	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
+	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:501)
+	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:485)
+	at com.mysql.cj.exceptions.ExceptionFactory.createException(ExceptionFactory.java:52)
+	at com.mysql.cj.exceptions.ExceptionFactory.createException(ExceptionFactory.java:76)
+	at com.mysql.cj.protocol.a.authentication.CachingSha2PasswordPlugin.nextAuthenticationStep(CachingSha2PasswordPlugin.java:122)
+	at com.mysql.cj.protocol.a.authentication.CachingSha2PasswordPlugin.nextAuthenticationStep(CachingSha2PasswordPlugin.java:40)
+	at com.mysql.cj.protocol.a.NativeAuthenticationProvider.proceedHandshakeWithPluggableAuthentication(NativeAuthenticationProvider.java:436)
+	at com.mysql.cj.protocol.a.NativeAuthenticationProvider.connect(NativeAuthenticationProvider.java:206)
+	at com.mysql.cj.protocol.a.NativeProtocol.connect(NativeProtocol.java:1332)
+	at com.mysql.cj.NativeSession.connect(NativeSession.java:155)
+	at com.mysql.cj.jdbc.ConnectionImpl.connectOneTryOnly(ConnectionImpl.java:964)
+	at com.mysql.cj.jdbc.ConnectionImpl.createNewIO(ConnectionImpl.java:828)
+	... 34 common frames omitted
+2026-01-13 22:26:21 [background-preinit] INFO  o.h.validator.internal.util.Version - HV000001: Hibernate Validator 9.0.1.Final
+2026-01-13 22:26:21 [main] INFO  c.e.l.LearningExamManagerApplication - Starting LearningExamManagerApplication using Java 23.0.2 with PID 7491 (/Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager/build/classes/java/main started by fumikun.wen in /Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager)
+2026-01-13 22:26:21 [main] DEBUG c.e.l.LearningExamManagerApplication - Running with Spring Boot v4.0.1, Spring v7.0.2
+2026-01-13 22:26:21 [main] INFO  c.e.l.LearningExamManagerApplication - No active profile set, falling back to 1 default profile: "default"
+2026-01-13 22:26:22 [main] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Bootstrapping Spring Data JPA repositories in DEFAULT mode.
+2026-01-13 22:26:22 [main] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Finished Spring Data repository scanning in 29 ms. Found 4 JPA repository interfaces.
+2026-01-13 22:26:22 [main] INFO  o.s.boot.tomcat.TomcatWebServer - Tomcat initialized with port 8080 (http)
+2026-01-13 22:26:22 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8080"]
+2026-01-13 22:26:22 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
+2026-01-13 22:26:22 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/11.0.15]
+2026-01-13 22:26:22 [main] INFO  o.s.b.w.c.s.WebApplicationContextInitializer - Root WebApplicationContext: initialization completed in 567 ms
+2026-01-13 22:26:22 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Starting...
+2026-01-13 22:26:23 [main] WARN  o.s.b.w.s.s.c.AnnotationConfigServletWebServerApplicationContext - Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'entityManagerFactory' defined in class path resource [org/springframework/boot/hibernate/autoconfigure/HibernateJpaConfiguration.class]: Failed to initialize dependency 'flywayInitializer' of LoadTimeWeaverAware bean 'entityManagerFactory': Error creating bean with name 'flywayInitializer' defined in class path resource [org/springframework/boot/flyway/autoconfigure/FlywayAutoConfiguration$FlywayConfiguration.class]: Unable to obtain connection from database: Public Key Retrieval is not allowed
+------------------------------------------------------------------------------
+SQL State  : 08001
+Error Code : 0
+Message    : Public Key Retrieval is not allowed
+
+2026-01-13 22:26:23 [main] INFO  o.a.catalina.core.StandardService - Stopping service [Tomcat]
+2026-01-13 22:26:23 [main] INFO  o.s.b.a.l.ConditionEvaluationReportLogger - 
+
+Error starting ApplicationContext. To display the condition evaluation report re-run your application with 'debug' enabled.
+2026-01-13 22:26:23 [main] ERROR o.s.boot.SpringApplication - Application run failed
+org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'entityManagerFactory' defined in class path resource [org/springframework/boot/hibernate/autoconfigure/HibernateJpaConfiguration.class]: Failed to initialize dependency 'flywayInitializer' of LoadTimeWeaverAware bean 'entityManagerFactory': Error creating bean with name 'flywayInitializer' defined in class path resource [org/springframework/boot/flyway/autoconfigure/FlywayAutoConfiguration$FlywayConfiguration.class]: Unable to obtain connection from database: Public Key Retrieval is not allowed
+------------------------------------------------------------------------------
+SQL State  : 08001
+Error Code : 0
+Message    : Public Key Retrieval is not allowed
+
+	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:322)
+	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:201)
+	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:976)
+	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:620)
+	at org.springframework.boot.web.server.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:143)
+	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:756)
+	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:445)
+	at org.springframework.boot.SpringApplication.run(SpringApplication.java:321)
+	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1365)
+	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1354)
+	at com.example.learning_exam_manager.LearningExamManagerApplication.main(LearningExamManagerApplication.java:10)
+Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'flywayInitializer' defined in class path resource [org/springframework/boot/flyway/autoconfigure/FlywayAutoConfiguration$FlywayConfiguration.class]: Unable to obtain connection from database: Public Key Retrieval is not allowed
+------------------------------------------------------------------------------
+SQL State  : 08001
+Error Code : 0
+Message    : Public Key Retrieval is not allowed
+
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1817)
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:603)
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:525)
+	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:333)
+	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:371)
+	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:331)
+	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:196)
+	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:309)
+	... 10 common frames omitted
+Caused by: org.flywaydb.core.internal.exception.sqlExceptions.FlywaySqlUnableToConnectToDbException: Unable to obtain connection from database: Public Key Retrieval is not allowed
+------------------------------------------------------------------------------
+SQL State  : 08001
+Error Code : 0
+Message    : Public Key Retrieval is not allowed
+
+	at org.flywaydb.core.internal.jdbc.JdbcUtils.openConnection(JdbcUtils.java:70)
+	at org.flywaydb.core.internal.jdbc.JdbcConnectionFactory.<init>(JdbcConnectionFactory.java:76)
+	at org.flywaydb.core.FlywayExecutor.execute(FlywayExecutor.java:142)
+	at org.flywaydb.core.Flyway.migrate(Flyway.java:186)
+	at org.springframework.boot.flyway.autoconfigure.FlywayMigrationInitializer.afterPropertiesSet(FlywayMigrationInitializer.java:67)
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1864)
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1813)
+	... 17 common frames omitted
+Caused by: java.sql.SQLNonTransientConnectionException: Public Key Retrieval is not allowed
+	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:102)
+	at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:114)
+	at com.mysql.cj.jdbc.ConnectionImpl.createNewIO(ConnectionImpl.java:840)
+	at com.mysql.cj.jdbc.ConnectionImpl.<init>(ConnectionImpl.java:416)
+	at com.mysql.cj.jdbc.ConnectionImpl.getInstance(ConnectionImpl.java:237)
+	at com.mysql.cj.jdbc.NonRegisteringDriver.connect(NonRegisteringDriver.java:180)
+	at com.zaxxer.hikari.util.DriverDataSource.getConnection(DriverDataSource.java:144)
+	at com.zaxxer.hikari.pool.PoolBase.newConnection(PoolBase.java:373)
+	at com.zaxxer.hikari.pool.PoolBase.newPoolEntry(PoolBase.java:210)
+	at com.zaxxer.hikari.pool.HikariPool.createPoolEntry(HikariPool.java:488)
+	at com.zaxxer.hikari.pool.HikariPool.checkFailFast(HikariPool.java:576)
+	at com.zaxxer.hikari.pool.HikariPool.<init>(HikariPool.java:97)
+	at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:111)
+	at org.flywaydb.core.internal.jdbc.JdbcUtils.openConnection(JdbcUtils.java:65)
+	... 23 common frames omitted
+Caused by: com.mysql.cj.exceptions.UnableToConnectException: Public Key Retrieval is not allowed
+	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
+	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:501)
+	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:485)
+	at com.mysql.cj.exceptions.ExceptionFactory.createException(ExceptionFactory.java:52)
+	at com.mysql.cj.exceptions.ExceptionFactory.createException(ExceptionFactory.java:76)
+	at com.mysql.cj.protocol.a.authentication.CachingSha2PasswordPlugin.nextAuthenticationStep(CachingSha2PasswordPlugin.java:122)
+	at com.mysql.cj.protocol.a.authentication.CachingSha2PasswordPlugin.nextAuthenticationStep(CachingSha2PasswordPlugin.java:40)
+	at com.mysql.cj.protocol.a.NativeAuthenticationProvider.proceedHandshakeWithPluggableAuthentication(NativeAuthenticationProvider.java:436)
+	at com.mysql.cj.protocol.a.NativeAuthenticationProvider.connect(NativeAuthenticationProvider.java:206)
+	at com.mysql.cj.protocol.a.NativeProtocol.connect(NativeProtocol.java:1332)
+	at com.mysql.cj.NativeSession.connect(NativeSession.java:155)
+	at com.mysql.cj.jdbc.ConnectionImpl.connectOneTryOnly(ConnectionImpl.java:964)
+	at com.mysql.cj.jdbc.ConnectionImpl.createNewIO(ConnectionImpl.java:828)
+	... 34 common frames omitted
+2026-01-13 22:30:22 [background-preinit] INFO  o.h.validator.internal.util.Version - HV000001: Hibernate Validator 9.0.1.Final
+2026-01-13 22:30:22 [main] INFO  c.e.l.LearningExamManagerApplication - Starting LearningExamManagerApplication using Java 23.0.2 with PID 9598 (/Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager/build/classes/java/main started by fumikun.wen in /Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager)
+2026-01-13 22:30:22 [main] DEBUG c.e.l.LearningExamManagerApplication - Running with Spring Boot v4.0.1, Spring v7.0.2
+2026-01-13 22:30:22 [main] INFO  c.e.l.LearningExamManagerApplication - No active profile set, falling back to 1 default profile: "default"
+2026-01-13 22:30:22 [main] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Bootstrapping Spring Data JPA repositories in DEFAULT mode.
+2026-01-13 22:30:22 [main] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Finished Spring Data repository scanning in 20 ms. Found 4 JPA repository interfaces.
+2026-01-13 22:30:22 [main] INFO  o.s.boot.tomcat.TomcatWebServer - Tomcat initialized with port 8080 (http)
+2026-01-13 22:30:22 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8080"]
+2026-01-13 22:30:22 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
+2026-01-13 22:30:22 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/11.0.15]
+2026-01-13 22:30:22 [main] INFO  o.s.b.w.c.s.WebApplicationContextInitializer - Root WebApplicationContext: initialization completed in 478 ms
+2026-01-13 22:30:22 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Starting...
+2026-01-13 22:30:23 [main] INFO  com.zaxxer.hikari.pool.HikariPool - HikariPool-1 - Added connection com.mysql.cj.jdbc.ConnectionImpl@1fc0d9b4
+2026-01-13 22:30:23 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Start completed.
+2026-01-13 22:30:23 [main] INFO  org.flywaydb.core.FlywayExecutor - Database: jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8&allowPublicKeyRetrieval=true (MySQL 9.3)
+2026-01-13 22:30:23 [main] WARN  o.f.c.i.database.base.Database - Using MySQL 9.3 which is newer than the version Flyway has been verified with. The latest verified version of MySQL is 8.1.
+2026-01-13 22:30:23 [main] INFO  o.f.core.internal.command.DbValidate - Successfully validated 2 migrations (execution time 00:00.018s)
+2026-01-13 22:30:23 [main] INFO  o.f.core.internal.command.DbMigrate - Current version of schema `learning_exam_manager`: 2
+2026-01-13 22:30:23 [main] INFO  o.f.core.internal.command.DbMigrate - Schema `learning_exam_manager` is up to date. No migration necessary.
+2026-01-13 22:30:23 [main] INFO  org.hibernate.orm.jpa - HHH008540: Processing PersistenceUnitInfo [name: default]
+2026-01-13 22:30:23 [main] INFO  org.hibernate.orm.core - HHH000001: Hibernate ORM core version 7.2.0.Final
+2026-01-13 22:30:23 [main] INFO  o.s.o.j.p.SpringPersistenceUnitInfo - No LoadTimeWeaver setup: ignoring JPA class transformer
+2026-01-13 22:30:23 [main] WARN  org.hibernate.orm.deprecation - HHH90000025: MySQLDialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
+2026-01-13 22:30:23 [main] INFO  o.hibernate.orm.connections.pooling - HHH10001005: Database info:
+	Database JDBC URL [jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8&allowPublicKeyRetrieval=true]
 	Database driver: MySQL Connector/J
 	Database dialect: MySQLDialect
 	Database version: 9.3
@@ -28,470 +233,21 @@
 	Pool: DataSourceConnectionProvider
 	Minimum pool size: undefined/unknown
 	Maximum pool size: undefined/unknown
-2026-01-12 22:15:12 [Test worker] INFO  org.hibernate.orm.core - HHH000489: No JTA platform available (set 'hibernate.transaction.jta.platform' to enable JTA platform integration)
-2026-01-12 22:15:12 [Test worker] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Initialized JPA EntityManagerFactory for persistence unit 'default'
-2026-01-12 22:15:12 [Test worker] INFO  o.s.d.j.r.q.QueryEnhancerFactories - Hibernate is in classpath; If applicable, HQL parser will be used.
-2026-01-12 22:15:12 [Test worker] WARN  o.s.b.j.a.JpaBaseConfiguration$JpaWebConfiguration - spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering. Explicitly configure spring.jpa.open-in-view to disable this warning
-2026-01-12 22:15:13 [Test worker] INFO  c.e.l.LearningExamManagerApplicationTests - Started LearningExamManagerApplicationTests in 2.493 seconds (process running for 3.085)
-2026-01-12 22:15:13 [SpringApplicationShutdownHook] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Closing JPA EntityManagerFactory for persistence unit 'default'
-2026-01-12 22:15:13 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown initiated...
-2026-01-12 22:15:13 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown completed.
-2026-01-12 22:19:46 [background-preinit] INFO  o.h.validator.internal.util.Version - HV000001: Hibernate Validator 9.0.1.Final
-2026-01-12 22:19:46 [Test worker] INFO  c.e.l.LearningExamManagerApplicationTests - Starting LearningExamManagerApplicationTests using Java 23.0.2 with PID 32567 (started by fumikun.wen in /Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager)
-2026-01-12 22:19:46 [Test worker] DEBUG c.e.l.LearningExamManagerApplicationTests - Running with Spring Boot v4.0.1, Spring v7.0.2
-2026-01-12 22:19:46 [Test worker] INFO  c.e.l.LearningExamManagerApplicationTests - No active profile set, falling back to 1 default profile: "default"
-2026-01-12 22:19:46 [Test worker] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Bootstrapping Spring Data JPA repositories in DEFAULT mode.
-2026-01-12 22:19:46 [Test worker] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Finished Spring Data repository scanning in 21 ms. Found 4 JPA repository interfaces.
-2026-01-12 22:19:46 [Test worker] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Starting...
-2026-01-12 22:19:46 [Test worker] INFO  com.zaxxer.hikari.pool.HikariPool - HikariPool-1 - Added connection com.mysql.cj.jdbc.ConnectionImpl@53e4a19e
-2026-01-12 22:19:46 [Test worker] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Start completed.
-2026-01-12 22:19:46 [Test worker] INFO  org.flywaydb.core.FlywayExecutor - Database: jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8 (MySQL 9.3)
-2026-01-12 22:19:46 [Test worker] WARN  o.f.c.i.database.base.Database - Using MySQL 9.3 which is newer than the version Flyway has been verified with. The latest verified version of MySQL is 8.1.
-2026-01-12 22:19:46 [Test worker] INFO  o.f.core.internal.command.DbValidate - Successfully validated 2 migrations (execution time 00:00.020s)
-2026-01-12 22:19:46 [Test worker] INFO  o.f.core.internal.command.DbMigrate - Current version of schema `learning_exam_manager`: 2
-2026-01-12 22:19:46 [Test worker] INFO  o.f.core.internal.command.DbMigrate - Schema `learning_exam_manager` is up to date. No migration necessary.
-2026-01-12 22:19:46 [Test worker] INFO  org.hibernate.orm.jpa - HHH008540: Processing PersistenceUnitInfo [name: default]
-2026-01-12 22:19:46 [Test worker] INFO  org.hibernate.orm.core - HHH000001: Hibernate ORM core version 7.2.0.Final
-2026-01-12 22:19:46 [Test worker] INFO  o.s.o.j.p.SpringPersistenceUnitInfo - No LoadTimeWeaver setup: ignoring JPA class transformer
-2026-01-12 22:19:47 [Test worker] WARN  org.hibernate.orm.deprecation - HHH90000025: MySQLDialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
-2026-01-12 22:19:47 [Test worker] INFO  o.hibernate.orm.connections.pooling - HHH10001005: Database info:
-	Database JDBC URL [jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8]
-	Database driver: MySQL Connector/J
-	Database dialect: MySQLDialect
-	Database version: 9.3
-	Default catalog/schema: learning_exam_manager/undefined
-	Autocommit mode: undefined/unknown
-	Isolation level: REPEATABLE_READ [default REPEATABLE_READ]
-	JDBC fetch size: none
-	Pool: DataSourceConnectionProvider
-	Minimum pool size: undefined/unknown
-	Maximum pool size: undefined/unknown
-2026-01-12 22:19:47 [Test worker] INFO  org.hibernate.orm.core - HHH000489: No JTA platform available (set 'hibernate.transaction.jta.platform' to enable JTA platform integration)
-2026-01-12 22:19:47 [Test worker] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Initialized JPA EntityManagerFactory for persistence unit 'default'
-2026-01-12 22:19:47 [Test worker] INFO  o.s.d.j.r.q.QueryEnhancerFactories - Hibernate is in classpath; If applicable, HQL parser will be used.
-2026-01-12 22:19:48 [Test worker] WARN  o.s.b.j.a.JpaBaseConfiguration$JpaWebConfiguration - spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering. Explicitly configure spring.jpa.open-in-view to disable this warning
-2026-01-12 22:19:48 [Test worker] INFO  c.e.l.LearningExamManagerApplicationTests - Started LearningExamManagerApplicationTests in 2.411 seconds (process running for 2.953)
-2026-01-12 22:19:48 [SpringApplicationShutdownHook] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Closing JPA EntityManagerFactory for persistence unit 'default'
-2026-01-12 22:19:48 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown initiated...
-2026-01-12 22:19:48 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown completed.
-2026-01-12 22:20:32 [background-preinit] INFO  o.h.validator.internal.util.Version - HV000001: Hibernate Validator 9.0.1.Final
-2026-01-12 22:20:32 [main] INFO  c.e.l.LearningExamManagerApplication - Starting LearningExamManagerApplication using Java 23.0.2 with PID 33326 (/Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager/build/classes/java/main started by fumikun.wen in /Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager)
-2026-01-12 22:20:32 [main] DEBUG c.e.l.LearningExamManagerApplication - Running with Spring Boot v4.0.1, Spring v7.0.2
-2026-01-12 22:20:32 [main] INFO  c.e.l.LearningExamManagerApplication - No active profile set, falling back to 1 default profile: "default"
-2026-01-12 22:20:33 [main] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Bootstrapping Spring Data JPA repositories in DEFAULT mode.
-2026-01-12 22:20:33 [main] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Finished Spring Data repository scanning in 20 ms. Found 4 JPA repository interfaces.
-2026-01-12 22:20:33 [main] INFO  o.s.boot.tomcat.TomcatWebServer - Tomcat initialized with port 8080 (http)
-2026-01-12 22:20:33 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8080"]
-2026-01-12 22:20:33 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
-2026-01-12 22:20:33 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/11.0.15]
-2026-01-12 22:20:33 [main] INFO  o.s.b.w.c.s.WebApplicationContextInitializer - Root WebApplicationContext: initialization completed in 523 ms
-2026-01-12 22:20:33 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Starting...
-2026-01-12 22:20:33 [main] INFO  com.zaxxer.hikari.pool.HikariPool - HikariPool-1 - Added connection com.mysql.cj.jdbc.ConnectionImpl@58164e9a
-2026-01-12 22:20:33 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Start completed.
-2026-01-12 22:20:33 [main] INFO  org.flywaydb.core.FlywayExecutor - Database: jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8 (MySQL 9.3)
-2026-01-12 22:20:33 [main] WARN  o.f.c.i.database.base.Database - Using MySQL 9.3 which is newer than the version Flyway has been verified with. The latest verified version of MySQL is 8.1.
-2026-01-12 22:20:33 [main] INFO  o.f.core.internal.command.DbValidate - Successfully validated 2 migrations (execution time 00:00.021s)
-2026-01-12 22:20:33 [main] INFO  o.f.core.internal.command.DbMigrate - Current version of schema `learning_exam_manager`: 2
-2026-01-12 22:20:33 [main] INFO  o.f.core.internal.command.DbMigrate - Schema `learning_exam_manager` is up to date. No migration necessary.
-2026-01-12 22:20:33 [main] INFO  org.hibernate.orm.jpa - HHH008540: Processing PersistenceUnitInfo [name: default]
-2026-01-12 22:20:33 [main] INFO  org.hibernate.orm.core - HHH000001: Hibernate ORM core version 7.2.0.Final
-2026-01-12 22:20:34 [main] INFO  o.s.o.j.p.SpringPersistenceUnitInfo - No LoadTimeWeaver setup: ignoring JPA class transformer
-2026-01-12 22:20:34 [main] WARN  org.hibernate.orm.deprecation - HHH90000025: MySQLDialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
-2026-01-12 22:20:34 [main] INFO  o.hibernate.orm.connections.pooling - HHH10001005: Database info:
-	Database JDBC URL [jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8]
-	Database driver: MySQL Connector/J
-	Database dialect: MySQLDialect
-	Database version: 9.3
-	Default catalog/schema: learning_exam_manager/undefined
-	Autocommit mode: undefined/unknown
-	Isolation level: REPEATABLE_READ [default REPEATABLE_READ]
-	JDBC fetch size: none
-	Pool: DataSourceConnectionProvider
-	Minimum pool size: undefined/unknown
-	Maximum pool size: undefined/unknown
-2026-01-12 22:20:34 [main] INFO  org.hibernate.orm.core - HHH000489: No JTA platform available (set 'hibernate.transaction.jta.platform' to enable JTA platform integration)
-2026-01-12 22:20:34 [main] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Initialized JPA EntityManagerFactory for persistence unit 'default'
-2026-01-12 22:20:34 [main] INFO  o.s.d.j.r.q.QueryEnhancerFactories - Hibernate is in classpath; If applicable, HQL parser will be used.
-2026-01-12 22:20:35 [main] WARN  o.s.b.j.a.JpaBaseConfiguration$JpaWebConfiguration - spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering. Explicitly configure spring.jpa.open-in-view to disable this warning
-2026-01-12 22:20:35 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8080"]
-2026-01-12 22:20:35 [main] INFO  o.s.boot.tomcat.TomcatWebServer - Tomcat started on port 8080 (http) with context path '/'
-2026-01-12 22:20:35 [main] INFO  c.e.l.LearningExamManagerApplication - Started LearningExamManagerApplication in 2.645 seconds (process running for 2.844)
-2026-01-12 22:20:45 [http-nio-8080-exec-1] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
-2026-01-12 22:20:45 [http-nio-8080-exec-1] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
-2026-01-12 22:20:45 [http-nio-8080-exec-1] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 2 ms
-2026-01-12 22:21:26 [http-nio-8080-exec-3] DEBUG c.e.l.service.SubjectService - すべての科目を取得します
-2026-01-12 22:21:26 [http-nio-8080-exec-3] INFO  c.e.l.service.SubjectService - 科目を10件取得しました
-2026-01-12 22:21:43 [http-nio-8080-exec-5] DEBUG c.e.l.controller.SubjectController - 科目一覧を表示します: keyword=null, page=0, size=10
-2026-01-12 22:21:43 [http-nio-8080-exec-5] DEBUG c.e.l.service.SubjectService - 科目一覧をページングして取得します
-2026-01-12 22:21:43 [http-nio-8080-exec-5] INFO  c.e.l.service.SubjectService - 科目を10件取得しました
-2026-01-12 22:21:43 [http-nio-8080-exec-5] INFO  c.e.l.controller.SubjectController - 科目一覧を表示しました: totalPages=1, totalItems=10, pageSize=10
-2026-01-12 22:22:01 [http-nio-8080-exec-7] DEBUG c.e.l.controller.SubjectController - 科目登録画面を表示します
-2026-01-12 22:22:01 [http-nio-8080-exec-7] INFO  c.e.l.controller.SubjectController - 科目登録画面を表示しました
-2026-01-12 22:22:04 [http-nio-8080-exec-9] INFO  c.e.l.service.SubjectService - 新しい科目を作成します: test
-2026-01-12 22:22:04 [http-nio-8080-exec-9] INFO  c.e.l.service.SubjectService - 科目を作成しました: ID=13, 名前=test
-2026-01-12 22:22:04 [http-nio-8080-exec-9] INFO  c.e.l.controller.SubjectController - 科目を登録しました: 名前=test
-2026-01-12 22:22:04 [http-nio-8080-exec-9] INFO  c.e.l.controller.SubjectController - リダイレクト先に遷移します
-2026-01-12 22:22:04 [http-nio-8080-exec-10] DEBUG c.e.l.controller.SubjectController - 科目一覧を表示します: keyword=null, page=0, size=10
-2026-01-12 22:22:04 [http-nio-8080-exec-10] DEBUG c.e.l.service.SubjectService - 科目一覧をページングして取得します
-2026-01-12 22:22:04 [http-nio-8080-exec-10] INFO  c.e.l.service.SubjectService - 科目を11件取得しました
-2026-01-12 22:22:04 [http-nio-8080-exec-10] INFO  c.e.l.controller.SubjectController - 科目一覧を表示しました: totalPages=2, totalItems=11, pageSize=10
-2026-01-12 22:25:18 [http-nio-8080-exec-2] DEBUG c.e.l.controller.SubjectController - 科目一覧を表示します: keyword=, page=1, size=10
-2026-01-12 22:25:18 [http-nio-8080-exec-2] DEBUG c.e.l.service.SubjectService - 科目一覧をページングして取得します
-2026-01-12 22:25:18 [http-nio-8080-exec-2] INFO  c.e.l.service.SubjectService - 科目を11件取得しました
-2026-01-12 22:25:18 [http-nio-8080-exec-2] INFO  c.e.l.controller.SubjectController - 科目一覧を表示しました: totalPages=2, totalItems=11, pageSize=10
-2026-01-12 22:28:27 [SpringApplicationShutdownHook] INFO  o.s.boot.tomcat.GracefulShutdown - Commencing graceful shutdown. Waiting for active requests to complete
-2026-01-12 22:28:27 [tomcat-shutdown] INFO  o.s.boot.tomcat.GracefulShutdown - Graceful shutdown complete
-2026-01-12 22:28:27 [SpringApplicationShutdownHook] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Closing JPA EntityManagerFactory for persistence unit 'default'
-2026-01-12 22:28:27 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown initiated...
-2026-01-12 22:28:27 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown completed.
-2026-01-12 22:28:52 [background-preinit] INFO  o.h.validator.internal.util.Version - HV000001: Hibernate Validator 9.0.1.Final
-2026-01-12 22:28:52 [main] INFO  c.e.l.LearningExamManagerApplication - Starting LearningExamManagerApplication using Java 23.0.2 with PID 37759 (/Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager/build/classes/java/main started by fumikun.wen in /Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager)
-2026-01-12 22:28:52 [main] DEBUG c.e.l.LearningExamManagerApplication - Running with Spring Boot v4.0.1, Spring v7.0.2
-2026-01-12 22:28:52 [main] INFO  c.e.l.LearningExamManagerApplication - No active profile set, falling back to 1 default profile: "default"
-2026-01-12 22:28:53 [main] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Bootstrapping Spring Data JPA repositories in DEFAULT mode.
-2026-01-12 22:28:53 [main] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Finished Spring Data repository scanning in 19 ms. Found 4 JPA repository interfaces.
-2026-01-12 22:28:53 [main] INFO  o.s.boot.tomcat.TomcatWebServer - Tomcat initialized with port 8080 (http)
-2026-01-12 22:28:53 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8080"]
-2026-01-12 22:28:53 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
-2026-01-12 22:28:53 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/11.0.15]
-2026-01-12 22:28:53 [main] INFO  o.s.b.w.c.s.WebApplicationContextInitializer - Root WebApplicationContext: initialization completed in 469 ms
-2026-01-12 22:28:53 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Starting...
-2026-01-12 22:28:53 [main] INFO  com.zaxxer.hikari.pool.HikariPool - HikariPool-1 - Added connection com.mysql.cj.jdbc.ConnectionImpl@4f26425b
-2026-01-12 22:28:53 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Start completed.
-2026-01-12 22:28:53 [main] INFO  org.flywaydb.core.FlywayExecutor - Database: jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8 (MySQL 9.3)
-2026-01-12 22:28:53 [main] WARN  o.f.c.i.database.base.Database - Using MySQL 9.3 which is newer than the version Flyway has been verified with. The latest verified version of MySQL is 8.1.
-2026-01-12 22:28:53 [main] INFO  o.f.core.internal.command.DbValidate - Successfully validated 2 migrations (execution time 00:00.016s)
-2026-01-12 22:28:53 [main] INFO  o.f.core.internal.command.DbMigrate - Current version of schema `learning_exam_manager`: 2
-2026-01-12 22:28:53 [main] INFO  o.f.core.internal.command.DbMigrate - Schema `learning_exam_manager` is up to date. No migration necessary.
-2026-01-12 22:28:53 [main] INFO  org.hibernate.orm.jpa - HHH008540: Processing PersistenceUnitInfo [name: default]
-2026-01-12 22:28:53 [main] INFO  org.hibernate.orm.core - HHH000001: Hibernate ORM core version 7.2.0.Final
-2026-01-12 22:28:54 [main] INFO  o.s.o.j.p.SpringPersistenceUnitInfo - No LoadTimeWeaver setup: ignoring JPA class transformer
-2026-01-12 22:28:54 [main] WARN  org.hibernate.orm.deprecation - HHH90000025: MySQLDialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
-2026-01-12 22:28:54 [main] INFO  o.hibernate.orm.connections.pooling - HHH10001005: Database info:
-	Database JDBC URL [jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8]
-	Database driver: MySQL Connector/J
-	Database dialect: MySQLDialect
-	Database version: 9.3
-	Default catalog/schema: learning_exam_manager/undefined
-	Autocommit mode: undefined/unknown
-	Isolation level: REPEATABLE_READ [default REPEATABLE_READ]
-	JDBC fetch size: none
-	Pool: DataSourceConnectionProvider
-	Minimum pool size: undefined/unknown
-	Maximum pool size: undefined/unknown
-2026-01-12 22:28:54 [main] INFO  org.hibernate.orm.core - HHH000489: No JTA platform available (set 'hibernate.transaction.jta.platform' to enable JTA platform integration)
-2026-01-12 22:28:54 [main] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Initialized JPA EntityManagerFactory for persistence unit 'default'
-2026-01-12 22:28:54 [main] INFO  o.s.d.j.r.q.QueryEnhancerFactories - Hibernate is in classpath; If applicable, HQL parser will be used.
-2026-01-12 22:28:55 [main] WARN  o.s.b.j.a.JpaBaseConfiguration$JpaWebConfiguration - spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering. Explicitly configure spring.jpa.open-in-view to disable this warning
-2026-01-12 22:28:55 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8080"]
-2026-01-12 22:28:55 [main] INFO  o.s.boot.tomcat.TomcatWebServer - Tomcat started on port 8080 (http) with context path '/'
-2026-01-12 22:28:55 [main] INFO  c.e.l.LearningExamManagerApplication - Started LearningExamManagerApplication in 2.487 seconds (process running for 2.66)
-2026-01-12 22:28:58 [http-nio-8080-exec-1] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
-2026-01-12 22:28:58 [http-nio-8080-exec-1] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
-2026-01-12 22:28:58 [http-nio-8080-exec-1] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 2 ms
-2026-01-12 22:28:58 [http-nio-8080-exec-1] DEBUG c.e.l.controller.SubjectController - 科目一覧を表示します: keyword=, page=1, size=10
-2026-01-12 22:28:58 [http-nio-8080-exec-1] DEBUG c.e.l.service.SubjectService - 科目一覧をページングして取得します
-2026-01-12 22:28:58 [http-nio-8080-exec-1] INFO  c.e.l.service.SubjectService - 科目を11件取得しました
-2026-01-12 22:28:58 [http-nio-8080-exec-1] INFO  c.e.l.controller.SubjectController - 科目一覧を表示しました: totalPages=2, totalItems=11, pageSize=10
-2026-01-12 22:29:22 [http-nio-8080-exec-5] DEBUG c.e.l.controller.SubjectController - 科目一覧を表示します: keyword=null, page=0, size=10
-2026-01-12 22:29:22 [http-nio-8080-exec-5] DEBUG c.e.l.service.SubjectService - 科目一覧をページングして取得します
-2026-01-12 22:29:22 [http-nio-8080-exec-5] INFO  c.e.l.service.SubjectService - 科目を11件取得しました
-2026-01-12 22:29:22 [http-nio-8080-exec-5] INFO  c.e.l.controller.SubjectController - 科目一覧を表示しました: totalPages=2, totalItems=11, pageSize=10
-2026-01-12 22:29:35 [http-nio-8080-exec-7] DEBUG c.e.l.controller.SubjectController - 科目一覧を表示します: keyword=, page=1, size=10
-2026-01-12 22:29:35 [http-nio-8080-exec-7] DEBUG c.e.l.service.SubjectService - 科目一覧をページングして取得します
-2026-01-12 22:29:35 [http-nio-8080-exec-7] INFO  c.e.l.service.SubjectService - 科目を11件取得しました
-2026-01-12 22:29:35 [http-nio-8080-exec-7] INFO  c.e.l.controller.SubjectController - 科目一覧を表示しました: totalPages=2, totalItems=11, pageSize=10
-2026-01-12 22:29:37 [http-nio-8080-exec-8] DEBUG c.e.l.controller.SubjectController - 科目一覧を表示します: keyword=, page=0, size=10
-2026-01-12 22:29:37 [http-nio-8080-exec-8] DEBUG c.e.l.service.SubjectService - 科目一覧をページングして取得します
-2026-01-12 22:29:37 [http-nio-8080-exec-8] INFO  c.e.l.service.SubjectService - 科目を11件取得しました
-2026-01-12 22:29:37 [http-nio-8080-exec-8] INFO  c.e.l.controller.SubjectController - 科目一覧を表示しました: totalPages=2, totalItems=11, pageSize=10
-2026-01-12 22:29:38 [http-nio-8080-exec-9] DEBUG c.e.l.controller.SubjectController - 科目一覧を表示します: keyword=, page=0, size=10
-2026-01-12 22:29:38 [http-nio-8080-exec-9] DEBUG c.e.l.service.SubjectService - 科目一覧をページングして取得します
-2026-01-12 22:29:38 [http-nio-8080-exec-9] INFO  c.e.l.service.SubjectService - 科目を11件取得しました
-2026-01-12 22:29:38 [http-nio-8080-exec-9] INFO  c.e.l.controller.SubjectController - 科目一覧を表示しました: totalPages=2, totalItems=11, pageSize=10
-2026-01-12 22:29:40 [http-nio-8080-exec-1] DEBUG c.e.l.controller.SubjectController - 科目一覧を表示します: keyword=, page=0, size=10
-2026-01-12 22:29:40 [http-nio-8080-exec-1] DEBUG c.e.l.service.SubjectService - 科目一覧をページングして取得します
-2026-01-12 22:29:40 [http-nio-8080-exec-1] INFO  c.e.l.service.SubjectService - 科目を11件取得しました
-2026-01-12 22:29:40 [http-nio-8080-exec-1] INFO  c.e.l.controller.SubjectController - 科目一覧を表示しました: totalPages=2, totalItems=11, pageSize=10
-2026-01-12 22:49:51 [SpringApplicationShutdownHook] INFO  o.s.boot.tomcat.GracefulShutdown - Commencing graceful shutdown. Waiting for active requests to complete
-2026-01-12 22:49:51 [tomcat-shutdown] INFO  o.s.boot.tomcat.GracefulShutdown - Graceful shutdown complete
-2026-01-12 22:49:51 [SpringApplicationShutdownHook] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Closing JPA EntityManagerFactory for persistence unit 'default'
-2026-01-12 22:49:52 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown initiated...
-2026-01-12 22:49:52 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown completed.
-2026-01-12 22:50:03 [background-preinit] INFO  o.h.validator.internal.util.Version - HV000001: Hibernate Validator 9.0.1.Final
-2026-01-12 22:50:03 [main] INFO  c.e.l.LearningExamManagerApplication - Starting LearningExamManagerApplication using Java 23.0.2 with PID 49250 (/Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager/build/classes/java/main started by fumikun.wen in /Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager)
-2026-01-12 22:50:03 [main] DEBUG c.e.l.LearningExamManagerApplication - Running with Spring Boot v4.0.1, Spring v7.0.2
-2026-01-12 22:50:03 [main] INFO  c.e.l.LearningExamManagerApplication - No active profile set, falling back to 1 default profile: "default"
-2026-01-12 22:50:04 [main] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Bootstrapping Spring Data JPA repositories in DEFAULT mode.
-2026-01-12 22:50:04 [main] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Finished Spring Data repository scanning in 20 ms. Found 4 JPA repository interfaces.
-2026-01-12 22:50:04 [main] INFO  o.s.boot.tomcat.TomcatWebServer - Tomcat initialized with port 8080 (http)
-2026-01-12 22:50:04 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8080"]
-2026-01-12 22:50:04 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
-2026-01-12 22:50:04 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/11.0.15]
-2026-01-12 22:50:04 [main] INFO  o.s.b.w.c.s.WebApplicationContextInitializer - Root WebApplicationContext: initialization completed in 626 ms
-2026-01-12 22:50:04 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Starting...
-2026-01-12 22:50:04 [main] INFO  com.zaxxer.hikari.pool.HikariPool - HikariPool-1 - Added connection com.mysql.cj.jdbc.ConnectionImpl@76e6c070
-2026-01-12 22:50:04 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Start completed.
-2026-01-12 22:50:04 [main] INFO  org.flywaydb.core.FlywayExecutor - Database: jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8 (MySQL 9.3)
-2026-01-12 22:50:04 [main] WARN  o.f.c.i.database.base.Database - Using MySQL 9.3 which is newer than the version Flyway has been verified with. The latest verified version of MySQL is 8.1.
-2026-01-12 22:50:04 [main] INFO  o.f.core.internal.command.DbValidate - Successfully validated 2 migrations (execution time 00:00.020s)
-2026-01-12 22:50:04 [main] INFO  o.f.core.internal.command.DbMigrate - Current version of schema `learning_exam_manager`: 2
-2026-01-12 22:50:04 [main] INFO  o.f.core.internal.command.DbMigrate - Schema `learning_exam_manager` is up to date. No migration necessary.
-2026-01-12 22:50:04 [main] INFO  org.hibernate.orm.jpa - HHH008540: Processing PersistenceUnitInfo [name: default]
-2026-01-12 22:50:04 [main] INFO  org.hibernate.orm.core - HHH000001: Hibernate ORM core version 7.2.0.Final
-2026-01-12 22:50:05 [main] INFO  o.s.o.j.p.SpringPersistenceUnitInfo - No LoadTimeWeaver setup: ignoring JPA class transformer
-2026-01-12 22:50:05 [main] WARN  org.hibernate.orm.deprecation - HHH90000025: MySQLDialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
-2026-01-12 22:50:05 [main] INFO  o.hibernate.orm.connections.pooling - HHH10001005: Database info:
-	Database JDBC URL [jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8]
-	Database driver: MySQL Connector/J
-	Database dialect: MySQLDialect
-	Database version: 9.3
-	Default catalog/schema: learning_exam_manager/undefined
-	Autocommit mode: undefined/unknown
-	Isolation level: REPEATABLE_READ [default REPEATABLE_READ]
-	JDBC fetch size: none
-	Pool: DataSourceConnectionProvider
-	Minimum pool size: undefined/unknown
-	Maximum pool size: undefined/unknown
-2026-01-12 22:50:05 [main] INFO  org.hibernate.orm.core - HHH000489: No JTA platform available (set 'hibernate.transaction.jta.platform' to enable JTA platform integration)
-2026-01-12 22:50:05 [main] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Initialized JPA EntityManagerFactory for persistence unit 'default'
-2026-01-12 22:50:05 [main] INFO  o.s.d.j.r.q.QueryEnhancerFactories - Hibernate is in classpath; If applicable, HQL parser will be used.
-2026-01-12 22:50:06 [main] WARN  o.s.b.j.a.JpaBaseConfiguration$JpaWebConfiguration - spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering. Explicitly configure spring.jpa.open-in-view to disable this warning
-2026-01-12 22:50:06 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8080"]
-2026-01-12 22:50:06 [main] INFO  o.s.boot.tomcat.TomcatWebServer - Tomcat started on port 8080 (http) with context path '/'
-2026-01-12 22:50:06 [main] INFO  c.e.l.LearningExamManagerApplication - Started LearningExamManagerApplication in 2.873 seconds (process running for 3.049)
-2026-01-12 22:50:09 [http-nio-8080-exec-1] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
-2026-01-12 22:50:09 [http-nio-8080-exec-1] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
-2026-01-12 22:50:09 [http-nio-8080-exec-1] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 3 ms
-2026-01-12 22:50:09 [http-nio-8080-exec-1] DEBUG c.e.l.controller.SubjectController - 科目一覧を表示します: keyword=, page=0, size=10
-2026-01-12 22:50:09 [http-nio-8080-exec-1] DEBUG c.e.l.service.SubjectService - 科目一覧をページングして取得します
-2026-01-12 22:50:09 [http-nio-8080-exec-1] INFO  c.e.l.service.SubjectService - 科目を11件取得しました
-2026-01-12 22:50:09 [http-nio-8080-exec-1] INFO  c.e.l.controller.SubjectController - 科目一覧を表示しました: totalPages=2, totalItems=11, pageSize=10
-2026-01-12 22:50:13 [http-nio-8080-exec-3] DEBUG c.e.l.controller.StudyItemController - 学習項目一覧を表示します: keyword=null, subjectId=null, page=0, size=10
-2026-01-12 22:50:13 [http-nio-8080-exec-3] DEBUG c.e.l.service.SubjectService - すべての科目を取得します
-2026-01-12 22:50:13 [http-nio-8080-exec-3] INFO  c.e.l.service.SubjectService - 科目を11件取得しました
-2026-01-12 22:50:13 [http-nio-8080-exec-3] INFO  c.e.l.controller.StudyItemController - 学習項目一覧を表示しました: totalPages=10, totalItems=100, pageSize=10
-2026-01-12 22:50:20 [http-nio-8080-exec-5] DEBUG c.e.l.controller.StudyItemController - 学習項目一覧を表示します: keyword=, subjectId=null, page=2, size=10
-2026-01-12 22:50:20 [http-nio-8080-exec-5] DEBUG c.e.l.service.SubjectService - すべての科目を取得します
-2026-01-12 22:50:20 [http-nio-8080-exec-5] INFO  c.e.l.service.SubjectService - 科目を11件取得しました
-2026-01-12 22:50:20 [http-nio-8080-exec-5] INFO  c.e.l.controller.StudyItemController - 学習項目一覧を表示しました: totalPages=10, totalItems=100, pageSize=10
-2026-01-12 22:50:25 [http-nio-8080-exec-7] DEBUG c.e.l.controller.StudyItemController - 学習項目一覧を表示します: keyword=, subjectId=null, page=6, size=10
-2026-01-12 22:50:25 [http-nio-8080-exec-7] DEBUG c.e.l.service.SubjectService - すべての科目を取得します
-2026-01-12 22:50:25 [http-nio-8080-exec-7] INFO  c.e.l.service.SubjectService - 科目を11件取得しました
-2026-01-12 22:50:25 [http-nio-8080-exec-7] INFO  c.e.l.controller.StudyItemController - 学習項目一覧を表示しました: totalPages=10, totalItems=100, pageSize=10
-2026-01-12 22:51:03 [http-nio-8080-exec-9] DEBUG c.e.l.controller.StudyItemController - 学習項目一覧を表示します: keyword=, subjectId=null, page=0, size=10
-2026-01-12 22:51:03 [http-nio-8080-exec-9] DEBUG c.e.l.service.SubjectService - すべての科目を取得します
-2026-01-12 22:51:03 [http-nio-8080-exec-9] INFO  c.e.l.service.SubjectService - 科目を11件取得しました
-2026-01-12 22:51:03 [http-nio-8080-exec-9] INFO  c.e.l.controller.StudyItemController - 学習項目一覧を表示しました: totalPages=10, totalItems=100, pageSize=10
-2026-01-12 22:58:07 [SpringApplicationShutdownHook] INFO  o.s.boot.tomcat.GracefulShutdown - Commencing graceful shutdown. Waiting for active requests to complete
-2026-01-12 22:58:07 [tomcat-shutdown] INFO  o.s.boot.tomcat.GracefulShutdown - Graceful shutdown complete
-2026-01-12 22:58:07 [SpringApplicationShutdownHook] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Closing JPA EntityManagerFactory for persistence unit 'default'
-2026-01-12 22:58:07 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown initiated...
-2026-01-12 22:58:07 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown completed.
-2026-01-12 22:58:26 [background-preinit] INFO  o.h.validator.internal.util.Version - HV000001: Hibernate Validator 9.0.1.Final
-2026-01-12 22:58:26 [main] INFO  c.e.l.LearningExamManagerApplication - Starting LearningExamManagerApplication using Java 23.0.2 with PID 53728 (/Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager/build/classes/java/main started by fumikun.wen in /Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager)
-2026-01-12 22:58:26 [main] DEBUG c.e.l.LearningExamManagerApplication - Running with Spring Boot v4.0.1, Spring v7.0.2
-2026-01-12 22:58:26 [main] INFO  c.e.l.LearningExamManagerApplication - No active profile set, falling back to 1 default profile: "default"
-2026-01-12 22:58:26 [main] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Bootstrapping Spring Data JPA repositories in DEFAULT mode.
-2026-01-12 22:58:26 [main] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Finished Spring Data repository scanning in 20 ms. Found 4 JPA repository interfaces.
-2026-01-12 22:58:26 [main] INFO  o.s.boot.tomcat.TomcatWebServer - Tomcat initialized with port 8080 (http)
-2026-01-12 22:58:26 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8080"]
-2026-01-12 22:58:26 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
-2026-01-12 22:58:26 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/11.0.15]
-2026-01-12 22:58:26 [main] INFO  o.s.b.w.c.s.WebApplicationContextInitializer - Root WebApplicationContext: initialization completed in 523 ms
-2026-01-12 22:58:26 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Starting...
-2026-01-12 22:58:26 [main] INFO  com.zaxxer.hikari.pool.HikariPool - HikariPool-1 - Added connection com.mysql.cj.jdbc.ConnectionImpl@4f26425b
-2026-01-12 22:58:26 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Start completed.
-2026-01-12 22:58:26 [main] INFO  org.flywaydb.core.FlywayExecutor - Database: jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8 (MySQL 9.3)
-2026-01-12 22:58:26 [main] WARN  o.f.c.i.database.base.Database - Using MySQL 9.3 which is newer than the version Flyway has been verified with. The latest verified version of MySQL is 8.1.
-2026-01-12 22:58:26 [main] INFO  o.f.core.internal.command.DbValidate - Successfully validated 2 migrations (execution time 00:00.019s)
-2026-01-12 22:58:26 [main] INFO  o.f.core.internal.command.DbMigrate - Current version of schema `learning_exam_manager`: 2
-2026-01-12 22:58:26 [main] INFO  o.f.core.internal.command.DbMigrate - Schema `learning_exam_manager` is up to date. No migration necessary.
-2026-01-12 22:58:26 [main] INFO  org.hibernate.orm.jpa - HHH008540: Processing PersistenceUnitInfo [name: default]
-2026-01-12 22:58:27 [main] INFO  org.hibernate.orm.core - HHH000001: Hibernate ORM core version 7.2.0.Final
-2026-01-12 22:58:27 [main] INFO  o.s.o.j.p.SpringPersistenceUnitInfo - No LoadTimeWeaver setup: ignoring JPA class transformer
-2026-01-12 22:58:27 [main] WARN  org.hibernate.orm.deprecation - HHH90000025: MySQLDialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
-2026-01-12 22:58:27 [main] INFO  o.hibernate.orm.connections.pooling - HHH10001005: Database info:
-	Database JDBC URL [jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8]
-	Database driver: MySQL Connector/J
-	Database dialect: MySQLDialect
-	Database version: 9.3
-	Default catalog/schema: learning_exam_manager/undefined
-	Autocommit mode: undefined/unknown
-	Isolation level: REPEATABLE_READ [default REPEATABLE_READ]
-	JDBC fetch size: none
-	Pool: DataSourceConnectionProvider
-	Minimum pool size: undefined/unknown
-	Maximum pool size: undefined/unknown
-2026-01-12 22:58:27 [main] INFO  org.hibernate.orm.core - HHH000489: No JTA platform available (set 'hibernate.transaction.jta.platform' to enable JTA platform integration)
-2026-01-12 22:58:27 [main] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Initialized JPA EntityManagerFactory for persistence unit 'default'
-2026-01-12 22:58:27 [main] INFO  o.s.d.j.r.q.QueryEnhancerFactories - Hibernate is in classpath; If applicable, HQL parser will be used.
-2026-01-12 22:58:28 [main] WARN  o.s.b.j.a.JpaBaseConfiguration$JpaWebConfiguration - spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering. Explicitly configure spring.jpa.open-in-view to disable this warning
-2026-01-12 22:58:28 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8080"]
-2026-01-12 22:58:28 [main] INFO  o.s.boot.tomcat.TomcatWebServer - Tomcat started on port 8080 (http) with context path '/'
-2026-01-12 22:58:28 [main] INFO  c.e.l.LearningExamManagerApplication - Started LearningExamManagerApplication in 2.609 seconds (process running for 2.799)
-2026-01-12 22:58:29 [http-nio-8080-exec-1] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
-2026-01-12 22:58:29 [http-nio-8080-exec-1] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
-2026-01-12 22:58:29 [http-nio-8080-exec-1] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 1 ms
-2026-01-12 22:58:29 [http-nio-8080-exec-1] DEBUG c.e.l.controller.StudyItemController - 学習項目一覧を表示します: keyword=, subjectId=null, page=0, size=10
-2026-01-12 22:58:29 [http-nio-8080-exec-1] DEBUG c.e.l.service.SubjectService - すべての科目を取得します
-2026-01-12 22:58:29 [http-nio-8080-exec-1] INFO  c.e.l.service.SubjectService - 科目を11件取得しました
-2026-01-12 22:58:29 [http-nio-8080-exec-1] INFO  c.e.l.controller.StudyItemController - 学習項目一覧を表示しました: totalPages=10, totalItems=100, pageSize=10
-2026-01-12 22:58:32 [http-nio-8080-exec-2] DEBUG c.e.l.controller.ExamController - 試験一覧を表示します: keyword=null, page=0, size=10
-2026-01-12 22:58:32 [http-nio-8080-exec-2] DEBUG c.e.l.service.ExamService - 試験一覧をページングして取得します
-2026-01-12 22:58:32 [http-nio-8080-exec-2] INFO  c.e.l.service.ExamService - 試験を18件取得しました
-2026-01-12 22:58:32 [http-nio-8080-exec-2] INFO  c.e.l.controller.ExamController - 試験一覧を表示しました: totalPages=2, totalItems=18, pageSize=10
-2026-01-12 22:58:36 [http-nio-8080-exec-4] DEBUG c.e.l.controller.ExamController - 試験一覧を表示します: keyword=, page=1, size=10
-2026-01-12 22:58:36 [http-nio-8080-exec-4] DEBUG c.e.l.service.ExamService - 試験一覧をページングして取得します
-2026-01-12 22:58:36 [http-nio-8080-exec-4] INFO  c.e.l.service.ExamService - 試験を18件取得しました
-2026-01-12 22:58:36 [http-nio-8080-exec-4] INFO  c.e.l.controller.ExamController - 試験一覧を表示しました: totalPages=2, totalItems=18, pageSize=10
-2026-01-12 22:59:02 [http-nio-8080-exec-6] DEBUG c.e.l.controller.ExamController - 試験登録画面を表示します
-2026-01-12 22:59:02 [http-nio-8080-exec-6] DEBUG c.e.l.service.SubjectService - すべての科目を取得します
-2026-01-12 22:59:02 [http-nio-8080-exec-6] INFO  c.e.l.service.SubjectService - 科目を11件取得しました
-2026-01-12 22:59:02 [http-nio-8080-exec-6] INFO  c.e.l.controller.ExamController - 試験登録画面を表示しました
-2026-01-12 22:59:13 [http-nio-8080-exec-8] INFO  c.e.l.service.ExamService - 新しい試験を作成します: java
-2026-01-12 22:59:13 [http-nio-8080-exec-8] INFO  c.e.l.service.ExamService - 試験を作成しました: ID=19, 試験名=java
-2026-01-12 22:59:13 [http-nio-8080-exec-8] INFO  c.e.l.controller.ExamController - 試験を登録しました: 試験名=java
-2026-01-12 22:59:13 [http-nio-8080-exec-9] DEBUG c.e.l.controller.ExamController - 試験一覧を表示します: keyword=null, page=0, size=10
-2026-01-12 22:59:13 [http-nio-8080-exec-9] DEBUG c.e.l.service.ExamService - 試験一覧をページングして取得します
-2026-01-12 22:59:13 [http-nio-8080-exec-9] INFO  c.e.l.service.ExamService - 試験を19件取得しました
-2026-01-12 22:59:13 [http-nio-8080-exec-9] INFO  c.e.l.controller.ExamController - 試験一覧を表示しました: totalPages=2, totalItems=19, pageSize=10
-2026-01-12 23:00:06 [http-nio-8080-exec-1] DEBUG c.e.l.controller.ExamController - 試験一覧を表示します: keyword=, page=1, size=10
-2026-01-12 23:00:06 [http-nio-8080-exec-1] DEBUG c.e.l.service.ExamService - 試験一覧をページングして取得します
-2026-01-12 23:00:06 [http-nio-8080-exec-1] INFO  c.e.l.service.ExamService - 試験を19件取得しました
-2026-01-12 23:00:06 [http-nio-8080-exec-1] INFO  c.e.l.controller.ExamController - 試験一覧を表示しました: totalPages=2, totalItems=19, pageSize=10
-2026-01-12 23:00:11 [http-nio-8080-exec-3] WARN  c.e.l.controller.ExamController - 試験を削除します: ID=19
-2026-01-12 23:00:11 [http-nio-8080-exec-3] WARN  c.e.l.service.ExamService - 試験を削除します: ID=19
-2026-01-12 23:00:11 [http-nio-8080-exec-3] INFO  c.e.l.service.ExamService - 試験を削除しました: ID=19
-2026-01-12 23:00:11 [http-nio-8080-exec-3] INFO  c.e.l.controller.ExamController - 試験を削除しました: ID=19
-2026-01-12 23:00:11 [http-nio-8080-exec-4] DEBUG c.e.l.controller.ExamController - 試験一覧を表示します: keyword=null, page=0, size=10
-2026-01-12 23:00:11 [http-nio-8080-exec-4] DEBUG c.e.l.service.ExamService - 試験一覧をページングして取得します
-2026-01-12 23:00:11 [http-nio-8080-exec-4] INFO  c.e.l.service.ExamService - 試験を18件取得しました
-2026-01-12 23:00:11 [http-nio-8080-exec-4] INFO  c.e.l.controller.ExamController - 試験一覧を表示しました: totalPages=2, totalItems=18, pageSize=10
-2026-01-12 23:03:15 [background-preinit] INFO  o.h.validator.internal.util.Version - HV000001: Hibernate Validator 9.0.1.Final
-2026-01-12 23:03:15 [Test worker] INFO  c.e.l.LearningExamManagerApplicationTests - Starting LearningExamManagerApplicationTests using Java 23.0.2 with PID 56272 (started by fumikun.wen in /Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager)
-2026-01-12 23:03:15 [Test worker] DEBUG c.e.l.LearningExamManagerApplicationTests - Running with Spring Boot v4.0.1, Spring v7.0.2
-2026-01-12 23:03:15 [Test worker] INFO  c.e.l.LearningExamManagerApplicationTests - No active profile set, falling back to 1 default profile: "default"
-2026-01-12 23:03:16 [Test worker] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Bootstrapping Spring Data JPA repositories in DEFAULT mode.
-2026-01-12 23:03:16 [Test worker] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Finished Spring Data repository scanning in 32 ms. Found 4 JPA repository interfaces.
-2026-01-12 23:03:16 [Test worker] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Starting...
-2026-01-12 23:03:16 [Test worker] INFO  com.zaxxer.hikari.pool.HikariPool - HikariPool-1 - Added connection com.mysql.cj.jdbc.ConnectionImpl@38ebc866
-2026-01-12 23:03:16 [Test worker] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Start completed.
-2026-01-12 23:03:16 [Test worker] INFO  org.flywaydb.core.FlywayExecutor - Database: jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8 (MySQL 9.3)
-2026-01-12 23:03:16 [Test worker] WARN  o.f.c.i.database.base.Database - Using MySQL 9.3 which is newer than the version Flyway has been verified with. The latest verified version of MySQL is 8.1.
-2026-01-12 23:03:16 [Test worker] INFO  o.f.core.internal.command.DbValidate - Successfully validated 2 migrations (execution time 00:00.031s)
-2026-01-12 23:03:16 [Test worker] INFO  o.f.core.internal.command.DbMigrate - Current version of schema `learning_exam_manager`: 2
-2026-01-12 23:03:16 [Test worker] INFO  o.f.core.internal.command.DbMigrate - Schema `learning_exam_manager` is up to date. No migration necessary.
-2026-01-12 23:03:17 [Test worker] INFO  org.hibernate.orm.jpa - HHH008540: Processing PersistenceUnitInfo [name: default]
-2026-01-12 23:03:17 [Test worker] INFO  org.hibernate.orm.core - HHH000001: Hibernate ORM core version 7.2.0.Final
-2026-01-12 23:03:17 [Test worker] INFO  o.s.o.j.p.SpringPersistenceUnitInfo - No LoadTimeWeaver setup: ignoring JPA class transformer
-2026-01-12 23:03:17 [Test worker] WARN  org.hibernate.orm.deprecation - HHH90000025: MySQLDialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
-2026-01-12 23:03:17 [Test worker] INFO  o.hibernate.orm.connections.pooling - HHH10001005: Database info:
-	Database JDBC URL [jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8]
-	Database driver: MySQL Connector/J
-	Database dialect: MySQLDialect
-	Database version: 9.3
-	Default catalog/schema: learning_exam_manager/undefined
-	Autocommit mode: undefined/unknown
-	Isolation level: REPEATABLE_READ [default REPEATABLE_READ]
-	JDBC fetch size: none
-	Pool: DataSourceConnectionProvider
-	Minimum pool size: undefined/unknown
-	Maximum pool size: undefined/unknown
-2026-01-12 23:03:17 [Test worker] INFO  org.hibernate.orm.core - HHH000489: No JTA platform available (set 'hibernate.transaction.jta.platform' to enable JTA platform integration)
-2026-01-12 23:03:17 [Test worker] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Initialized JPA EntityManagerFactory for persistence unit 'default'
-2026-01-12 23:03:17 [Test worker] INFO  o.s.d.j.r.q.QueryEnhancerFactories - Hibernate is in classpath; If applicable, HQL parser will be used.
-2026-01-12 23:03:18 [Test worker] WARN  o.s.b.j.a.JpaBaseConfiguration$JpaWebConfiguration - spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering. Explicitly configure spring.jpa.open-in-view to disable this warning
-2026-01-12 23:03:18 [Test worker] INFO  c.e.l.LearningExamManagerApplicationTests - Started LearningExamManagerApplicationTests in 2.962 seconds (process running for 3.539)
-2026-01-12 23:03:18 [SpringApplicationShutdownHook] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Closing JPA EntityManagerFactory for persistence unit 'default'
-2026-01-12 23:03:18 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown initiated...
-2026-01-12 23:03:18 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown completed.
-2026-01-12 23:03:44 [SpringApplicationShutdownHook] INFO  o.s.boot.tomcat.GracefulShutdown - Commencing graceful shutdown. Waiting for active requests to complete
-2026-01-12 23:03:44 [tomcat-shutdown] INFO  o.s.boot.tomcat.GracefulShutdown - Graceful shutdown complete
-2026-01-12 23:03:44 [SpringApplicationShutdownHook] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Closing JPA EntityManagerFactory for persistence unit 'default'
-2026-01-12 23:03:44 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown initiated...
-2026-01-12 23:03:44 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown completed.
-2026-01-12 23:03:49 [background-preinit] INFO  o.h.validator.internal.util.Version - HV000001: Hibernate Validator 9.0.1.Final
-2026-01-12 23:03:49 [main] INFO  c.e.l.LearningExamManagerApplication - Starting LearningExamManagerApplication using Java 23.0.2 with PID 56825 (/Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager/build/classes/java/main started by fumikun.wen in /Users/fumikun.wen/Desktop/project/Learning&Exam Manger app/learning-exam-manager)
-2026-01-12 23:03:49 [main] DEBUG c.e.l.LearningExamManagerApplication - Running with Spring Boot v4.0.1, Spring v7.0.2
-2026-01-12 23:03:49 [main] INFO  c.e.l.LearningExamManagerApplication - No active profile set, falling back to 1 default profile: "default"
-2026-01-12 23:03:49 [main] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Bootstrapping Spring Data JPA repositories in DEFAULT mode.
-2026-01-12 23:03:49 [main] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Finished Spring Data repository scanning in 19 ms. Found 4 JPA repository interfaces.
-2026-01-12 23:03:49 [main] INFO  o.s.boot.tomcat.TomcatWebServer - Tomcat initialized with port 8080 (http)
-2026-01-12 23:03:49 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8080"]
-2026-01-12 23:03:49 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
-2026-01-12 23:03:49 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/11.0.15]
-2026-01-12 23:03:49 [main] INFO  o.s.b.w.c.s.WebApplicationContextInitializer - Root WebApplicationContext: initialization completed in 462 ms
-2026-01-12 23:03:49 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Starting...
-2026-01-12 23:03:49 [main] INFO  com.zaxxer.hikari.pool.HikariPool - HikariPool-1 - Added connection com.mysql.cj.jdbc.ConnectionImpl@4f26425b
-2026-01-12 23:03:49 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Start completed.
-2026-01-12 23:03:49 [main] INFO  org.flywaydb.core.FlywayExecutor - Database: jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8 (MySQL 9.3)
-2026-01-12 23:03:49 [main] WARN  o.f.c.i.database.base.Database - Using MySQL 9.3 which is newer than the version Flyway has been verified with. The latest verified version of MySQL is 8.1.
-2026-01-12 23:03:50 [main] INFO  o.f.core.internal.command.DbValidate - Successfully validated 2 migrations (execution time 00:00.021s)
-2026-01-12 23:03:50 [main] INFO  o.f.core.internal.command.DbMigrate - Current version of schema `learning_exam_manager`: 2
-2026-01-12 23:03:50 [main] INFO  o.f.core.internal.command.DbMigrate - Schema `learning_exam_manager` is up to date. No migration necessary.
-2026-01-12 23:03:50 [main] INFO  org.hibernate.orm.jpa - HHH008540: Processing PersistenceUnitInfo [name: default]
-2026-01-12 23:03:50 [main] INFO  org.hibernate.orm.core - HHH000001: Hibernate ORM core version 7.2.0.Final
-2026-01-12 23:03:50 [main] INFO  o.s.o.j.p.SpringPersistenceUnitInfo - No LoadTimeWeaver setup: ignoring JPA class transformer
-2026-01-12 23:03:50 [main] WARN  org.hibernate.orm.deprecation - HHH90000025: MySQLDialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
-2026-01-12 23:03:50 [main] INFO  o.hibernate.orm.connections.pooling - HHH10001005: Database info:
-	Database JDBC URL [jdbc:mysql://localhost:3306/learning_exam_manager?useSSL=false&serverTimezone=Asia/Tokyo&characterEncoding=utf8]
-	Database driver: MySQL Connector/J
-	Database dialect: MySQLDialect
-	Database version: 9.3
-	Default catalog/schema: learning_exam_manager/undefined
-	Autocommit mode: undefined/unknown
-	Isolation level: REPEATABLE_READ [default REPEATABLE_READ]
-	JDBC fetch size: none
-	Pool: DataSourceConnectionProvider
-	Minimum pool size: undefined/unknown
-	Maximum pool size: undefined/unknown
-2026-01-12 23:03:50 [main] INFO  org.hibernate.orm.core - HHH000489: No JTA platform available (set 'hibernate.transaction.jta.platform' to enable JTA platform integration)
-2026-01-12 23:03:50 [main] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Initialized JPA EntityManagerFactory for persistence unit 'default'
-2026-01-12 23:03:50 [main] INFO  o.s.d.j.r.q.QueryEnhancerFactories - Hibernate is in classpath; If applicable, HQL parser will be used.
-2026-01-12 23:03:51 [main] WARN  o.s.b.j.a.JpaBaseConfiguration$JpaWebConfiguration - spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering. Explicitly configure spring.jpa.open-in-view to disable this warning
-2026-01-12 23:03:51 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8080"]
-2026-01-12 23:03:51 [main] INFO  o.s.boot.tomcat.TomcatWebServer - Tomcat started on port 8080 (http) with context path '/'
-2026-01-12 23:03:51 [main] INFO  c.e.l.LearningExamManagerApplication - Started LearningExamManagerApplication in 2.413 seconds (process running for 2.594)
-2026-01-12 23:04:00 [http-nio-8080-exec-1] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
-2026-01-12 23:04:00 [http-nio-8080-exec-1] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
-2026-01-12 23:04:00 [http-nio-8080-exec-1] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 3 ms
-2026-01-12 23:04:00 [http-nio-8080-exec-1] DEBUG c.e.l.c.ExamResultController - 試験結果一覧を表示します: keyword=null, page=0, size=10
-2026-01-12 23:04:00 [http-nio-8080-exec-1] DEBUG c.e.l.service.ExamResultService - 試験結果一覧をページングして取得します
-2026-01-12 23:04:00 [http-nio-8080-exec-1] INFO  c.e.l.service.ExamResultService - 試験結果を64件取得しました
-2026-01-12 23:04:00 [http-nio-8080-exec-1] INFO  c.e.l.c.ExamResultController - 試験結果一覧を表示しました: totalPages=7, totalItems=64, pageSize=10
-2026-01-12 23:04:37 [http-nio-8080-exec-3] DEBUG c.e.l.c.ExamResultController - 試験結果登録画面を表示します
-2026-01-12 23:04:37 [http-nio-8080-exec-3] DEBUG c.e.l.service.ExamService - すべての試験を取得します
-2026-01-12 23:04:37 [http-nio-8080-exec-3] INFO  c.e.l.service.ExamService - 試験を18件取得しました
-2026-01-12 23:04:37 [http-nio-8080-exec-3] INFO  c.e.l.c.ExamResultController - 試験結果登録画面を表示しました
-2026-01-12 23:04:44 [http-nio-8080-exec-5] INFO  c.e.l.service.ExamResultService - 新しい試験結果を作成します: 試験ID=5, 得点=50
-2026-01-12 23:04:44 [http-nio-8080-exec-5] INFO  c.e.l.service.ExamResultService - 試験結果を作成しました: ID=65, 試験名=Spring Boot実践テスト, 得点=50, 合否=false
-2026-01-12 23:04:44 [http-nio-8080-exec-5] INFO  c.e.l.c.ExamResultController - 試験結果を登録しました: 試験ID=5, 得点=50
-2026-01-12 23:04:44 [http-nio-8080-exec-6] DEBUG c.e.l.c.ExamResultController - 試験結果一覧を表示します: keyword=null, page=0, size=10
-2026-01-12 23:04:44 [http-nio-8080-exec-6] DEBUG c.e.l.service.ExamResultService - 試験結果一覧をページングして取得します
-2026-01-12 23:04:44 [http-nio-8080-exec-6] INFO  c.e.l.service.ExamResultService - 試験結果を65件取得しました
-2026-01-12 23:04:44 [http-nio-8080-exec-6] INFO  c.e.l.c.ExamResultController - 試験結果一覧を表示しました: totalPages=7, totalItems=65, pageSize=10
-2026-01-12 23:05:08 [http-nio-8080-exec-8] DEBUG c.e.l.c.ExamResultController - 試験結果一覧を表示します: keyword=, page=6, size=10
-2026-01-12 23:05:08 [http-nio-8080-exec-8] DEBUG c.e.l.service.ExamResultService - 試験結果一覧をページングして取得します
-2026-01-12 23:05:08 [http-nio-8080-exec-8] INFO  c.e.l.service.ExamResultService - 試験結果を65件取得しました
-2026-01-12 23:05:08 [http-nio-8080-exec-8] INFO  c.e.l.c.ExamResultController - 試験結果一覧を表示しました: totalPages=7, totalItems=65, pageSize=10
-2026-01-12 23:05:11 [http-nio-8080-exec-9] DEBUG c.e.l.c.ExamResultController - 試験結果一覧を表示します: keyword=, page=5, size=10
-2026-01-12 23:05:11 [http-nio-8080-exec-9] DEBUG c.e.l.service.ExamResultService - 試験結果一覧をページングして取得します
-2026-01-12 23:05:11 [http-nio-8080-exec-9] INFO  c.e.l.service.ExamResultService - 試験結果を65件取得しました
-2026-01-12 23:05:11 [http-nio-8080-exec-9] INFO  c.e.l.c.ExamResultController - 試験結果一覧を表示しました: totalPages=7, totalItems=65, pageSize=10
-2026-01-12 23:05:16 [http-nio-8080-exec-1] DEBUG c.e.l.c.ExamResultController - 試験結果一覧を表示します: keyword=, page=1, size=10
-2026-01-12 23:05:16 [http-nio-8080-exec-1] DEBUG c.e.l.service.ExamResultService - 試験結果一覧をページングして取得します
-2026-01-12 23:05:16 [http-nio-8080-exec-1] INFO  c.e.l.service.ExamResultService - 試験結果を65件取得しました
-2026-01-12 23:05:16 [http-nio-8080-exec-1] INFO  c.e.l.c.ExamResultController - 試験結果一覧を表示しました: totalPages=7, totalItems=65, pageSize=10
-2026-01-12 23:05:18 [http-nio-8080-exec-3] DEBUG c.e.l.c.ExamResultController - 試験結果一覧を表示します: keyword=, page=0, size=10
-2026-01-12 23:05:18 [http-nio-8080-exec-3] DEBUG c.e.l.service.ExamResultService - 試験結果一覧をページングして取得します
-2026-01-12 23:05:18 [http-nio-8080-exec-3] INFO  c.e.l.service.ExamResultService - 試験結果を65件取得しました
-2026-01-12 23:05:18 [http-nio-8080-exec-3] INFO  c.e.l.c.ExamResultController - 試験結果一覧を表示しました: totalPages=7, totalItems=65, pageSize=10
-2026-01-12 23:05:33 [http-nio-8080-exec-5] WARN  c.e.l.c.ExamResultController - 試験結果を削除します: ID=65
-2026-01-12 23:05:33 [http-nio-8080-exec-5] WARN  c.e.l.service.ExamResultService - 試験結果を削除します: ID=65
-2026-01-12 23:05:33 [http-nio-8080-exec-5] INFO  c.e.l.service.ExamResultService - 試験結果を削除しました: ID=65
-2026-01-12 23:05:33 [http-nio-8080-exec-5] INFO  c.e.l.c.ExamResultController - 試験結果を削除しました: ID=65
-2026-01-12 23:05:33 [http-nio-8080-exec-6] DEBUG c.e.l.c.ExamResultController - 試験結果一覧を表示します: keyword=null, page=0, size=10
-2026-01-12 23:05:33 [http-nio-8080-exec-6] DEBUG c.e.l.service.ExamResultService - 試験結果一覧をページングして取得します
-2026-01-12 23:05:33 [http-nio-8080-exec-6] INFO  c.e.l.service.ExamResultService - 試験結果を64件取得しました
-2026-01-12 23:05:33 [http-nio-8080-exec-6] INFO  c.e.l.c.ExamResultController - 試験結果一覧を表示しました: totalPages=7, totalItems=64, pageSize=10
+2026-01-13 22:30:23 [main] INFO  org.hibernate.orm.core - HHH000489: No JTA platform available (set 'hibernate.transaction.jta.platform' to enable JTA platform integration)
+2026-01-13 22:30:24 [main] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Initialized JPA EntityManagerFactory for persistence unit 'default'
+2026-01-13 22:30:24 [main] INFO  o.s.d.j.r.q.QueryEnhancerFactories - Hibernate is in classpath; If applicable, HQL parser will be used.
+2026-01-13 22:30:24 [main] WARN  o.s.b.j.a.JpaBaseConfiguration$JpaWebConfiguration - spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering. Explicitly configure spring.jpa.open-in-view to disable this warning
+2026-01-13 22:30:24 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8080"]
+2026-01-13 22:30:24 [main] INFO  o.s.boot.tomcat.TomcatWebServer - Tomcat started on port 8080 (http) with context path '/'
+2026-01-13 22:30:24 [main] INFO  c.e.l.LearningExamManagerApplication - Started LearningExamManagerApplication in 2.653 seconds (process running for 2.831)
+2026-01-13 22:30:36 [http-nio-8080-exec-1] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
+2026-01-13 22:30:36 [http-nio-8080-exec-1] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
+2026-01-13 22:30:37 [http-nio-8080-exec-1] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 4 ms
+2026-01-13 22:30:37 [http-nio-8080-exec-1] DEBUG c.e.l.c.ExamResultController - 試験結果一覧を表示します: keyword=null, page=0, size=10
+2026-01-13 22:30:37 [http-nio-8080-exec-1] DEBUG c.e.l.service.ExamResultService - 試験結果一覧をページングして取得します
+2026-01-13 22:30:37 [http-nio-8080-exec-1] INFO  c.e.l.service.ExamResultService - 試験結果を64件取得しました
+2026-01-13 22:30:37 [http-nio-8080-exec-1] INFO  c.e.l.c.ExamResultController - 試験結果一覧を表示しました: totalPages=7, totalItems=64, pageSize=10
+2026-01-13 22:30:46 [http-nio-8080-exec-3] DEBUG c.e.l.controller.ExamController - 試験一覧を表示します: keyword=null, page=0, size=10
+2026-01-13 22:30:46 [http-nio-8080-exec-3] DEBUG c.e.l.service.ExamService - 試験一覧をページングして取得します
+2026-01-13 22:30:46 [http-nio-8080-exec-3] INFO  c.e.l.service.ExamService - 試験を18件取得しました
+2026-01-13 22:30:46 [http-nio-8080-exec-3] INFO  c.e.l.controller.ExamController - 試験一覧を表示しました: totalPages=2, totalItems=18, pageSize=10

--- a/src/main/resources/templates/error/400.html
+++ b/src/main/resources/templates/error/400.html
@@ -15,7 +15,7 @@
             <div class="col-md-8">
                 <div class="card">
                     <div class="card-body text-center">
-                        <h1 class="display-1 text-danger">404</h1>
+                        <h1 class="display-1 text-danger">400</h1>
                         <p class="lead" th:text="${error != null ? error : 'ページが見つかりません'}"></p>
                         <a href="/" class="btn btn-primary mt-3">ホームに戻る</a>
                     </div>


### PR DESCRIPTION
### 概要

本PRでは、アプリケーションのエラーハンドリングおよびログ処理周りの不具合修正を行っています。主に **404エラーページの修正** と **ログファイルクローズ漏れの解消** が目的です。

---

### 変更内容

- **404ページの修正**
  - 存在しないURLアクセス時に正しく404ページが表示されない問題を修正
  - ルーティングおよび関連設定を整理し、想定どおりの遷移になるよう改善
  - Issue #21 に対応

- **ログファイルのクローズ処理修正**
  - ログ出力後にファイルがクローズされない問題を修正
  - リソースリークを防止し、安定性を向上
  - Issue #22 に対応

---

### コミット一覧

- `fix:400page`（Issue #21 対応）
- `fix:log file close`（Issue #22 対応）

---

### 影響範囲・補足

- 変更ファイル数：4
- 追加行数：743行  
- 削除行数：489行  
- 既存機能への影響は限定的で、主に例外系・内部処理の改善が中心

---

### 確認事項

- 存在しないURLにアクセスした際、404ページが正しく表示されること
- アプリケーション実行後、ログファイルが適切にクローズされていること

以上。